### PR TITLE
IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,27 @@
 </p>
 
 Creates a test TUN interface, sets it as the preferred tethering upstream, and
-forwards hotspot traffic through a Go datapath.
+forwards hotspot traffic through a Go datapath. Supports IPv4 and IPv6.
 
-## Requirements
+## 📋 Requirements
 
 - Android 13 (API 33+), arm64
 - [Shizuku](https://shizuku.rikka.app/) 13.6.0+
 
-## Install
+## 📲 Install
 
 Download the APK from the
 [latest release](https://github.com/carlelieser/shizzi/releases/latest).
 
-## Build
+## ✨ Features
+
+- 🚀 **Unlimited hotspot.** Sharing draws on your regular data instead of your
+  hotspot allowance.
+- 🛡️ **VPN compatible.** Stay private on every connected device.
+- ⚙️ **Uses your existing hotspot.** No extra configuration required.
+- 🙌 **No root.** Shizuku is all it needs.
+
+## 🔨 Build
 
 Needs the Android SDK with NDK, Go, and gomobile:
 
@@ -29,8 +37,3 @@ Needs the Android SDK with NDK, Go, and gomobile:
 go install golang.org/x/mobile/cmd/gomobile@latest && gomobile init
 ./gradlew assembleDebug
 ```
-
-## Known limitations
-
-- IPv6 reaches clients only when the tethering stack provisions it on the
-  downstream; the datapath forwards v6, but it does not advertise a prefix.

--- a/README.md
+++ b/README.md
@@ -32,4 +32,5 @@ go install golang.org/x/mobile/cmd/gomobile@latest && gomobile init
 
 ## Known limitations
 
-- IPv6 is not suppressed on the downstream; v6 traffic may bypass the tunnel.
+- IPv6 reaches clients only when the tethering stack provisions it on the
+  downstream; the datapath forwards v6, but it does not advertise a prefix.

--- a/app/src/main/java/dev/shizzi/HiddenApi.kt
+++ b/app/src/main/java/dev/shizzi/HiddenApi.kt
@@ -61,7 +61,8 @@ object HiddenApiCatalog {
             since = 29,
             notes = "Signature changed across releases: API 29-30 take " +
                 "LinkAddress[], later releases take Collection<LinkAddress>. " +
-                "Both overloads are probed.",
+                "Both overloads are probed, and both are passed the IPv4 and " +
+                "IPv6 TUN addresses together.",
         ),
         HiddenApiPath(
             id = "TestNetworkManager.setupTestNetwork",
@@ -237,18 +238,18 @@ class TestNetworkApi(private val context: Context) {
     }
 
     /**
-     * Creates a TUN carrying [address].
+     * Creates a TUN carrying [addresses].
      *
      * Tries the Collection overload first (API 31+) then the array overload
      * (API 29-30), because the parameter type changed between releases.
      */
-    fun createTunInterface(address: LinkAddress): TunHandle {
+    fun createTunInterface(addresses: List<LinkAddress>): TunHandle {
         val instance = manager ?: error("createTunInterface: test_network service unavailable")
         val owner = managerClass ?: error("createTunInterface: TestNetworkManager class absent")
 
-        val created = invokeCollectionOverload(owner, instance, address)
-            ?: invokeArrayOverload(owner, instance, address)
-            ?: error("createTunInterface: no known overload accepted LinkAddress $address")
+        val created = invokeCollectionOverload(owner, instance, addresses)
+            ?: invokeArrayOverload(owner, instance, addresses)
+            ?: error("createTunInterface: no known overload accepted LinkAddresses $addresses")
 
         return TunHandle(created)
     }
@@ -256,21 +257,23 @@ class TestNetworkApi(private val context: Context) {
     private fun invokeCollectionOverload(
         owner: Class<*>,
         instance: Any,
-        address: LinkAddress,
+        addresses: List<LinkAddress>,
     ): Any? = runCatching {
         val method = owner.getMethod("createTunInterface", Collection::class.java)
-        method.invoke(instance, listOf(address))
+        method.invoke(instance, addresses)
     }.getOrNull()
 
     private fun invokeArrayOverload(
         owner: Class<*>,
         instance: Any,
-        address: LinkAddress,
+        addresses: List<LinkAddress>,
     ): Any? = runCatching {
         val arrayType = Class.forName("[Landroid.net.LinkAddress;")
         val method = owner.getMethod("createTunInterface", arrayType)
-        val argument = java.lang.reflect.Array.newInstance(LinkAddress::class.java, 1)
-        java.lang.reflect.Array.set(argument, 0, address)
+        val argument = java.lang.reflect.Array.newInstance(LinkAddress::class.java, addresses.size)
+        addresses.forEachIndexed { index, address ->
+            java.lang.reflect.Array.set(argument, index, address)
+        }
         method.invoke(instance, argument)
     }.getOrNull()
 

--- a/app/src/main/java/dev/shizzi/HiddenApi.kt
+++ b/app/src/main/java/dev/shizzi/HiddenApi.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.LinkAddress
+import android.net.LinkProperties
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.os.Build
@@ -69,8 +70,11 @@ object HiddenApiCatalog {
             className = "android.net.TestNetworkManager",
             memberName = "setupTestNetwork",
             since = 29,
-            notes = "Overload used takes (String iface, IBinder binder). " +
-                "Requires MANAGE_TEST_NETWORKS, held by shell UID 2000.",
+            notes = "The (LinkProperties, boolean, IBinder) overload is used so " +
+                "the network carries IPv6 DNS servers, without which tethering " +
+                "will not provision IPv6 downstream; falls back to " +
+                "(String iface, IBinder binder). Requires MANAGE_TEST_NETWORKS, " +
+                "held by shell UID 2000.",
         ),
         HiddenApiPath(
             id = "TestNetworkManager.teardownTestNetwork",
@@ -146,6 +150,15 @@ object HiddenApiCatalog {
         ),
     )
 }
+
+/**
+ * DNS servers the test network advertises.
+ *
+ * Not cosmetic: tethering's getIPv6Interface returns null unless the upstream
+ * has an IPv6 DNS server, and IPv6 is then never provisioned downstream.
+ */
+val TEST_NETWORK_DNS_SERVERS: List<InetAddress>
+    get() = listOf("2001:4860:4860::8888", "8.8.8.8").map(InetAddress::getByName)
 
 /**
  * Builds a [LinkAddress] without the package-private constructor.
@@ -277,13 +290,47 @@ class TestNetworkApi(private val context: Context) {
         method.invoke(instance, argument)
     }.getOrNull()
 
-    /** Registers [interfaceName] as a test network bound to the lifetime of [binder]. */
-    fun setupTestNetwork(interfaceName: String, binder: IBinder) {
+    /**
+     * Registers [interfaceName] as a test network bound to the lifetime of [binder].
+     *
+     * Registered with LinkProperties carrying [dnsServers], because tethering
+     * refuses to provision IPv6 downstream without them: getIPv6Interface
+     * requires hasIpv6DnsServer(), and the plain overload leaves the list
+     * empty. The interface name and link addresses in the LinkProperties are
+     * overwritten by the framework; only the DNS servers survive.
+     *
+     * Falls back to the plain overload when the LinkProperties one is absent,
+     * so a build without it still gets a working IPv4 session.
+     */
+    fun setupTestNetwork(interfaceName: String, dnsServers: List<InetAddress>, binder: IBinder) {
         val instance = manager ?: error("setupTestNetwork: test_network service unavailable")
         val owner = managerClass ?: error("setupTestNetwork: TestNetworkManager class absent")
+
+        val properties = LinkProperties().apply {
+            setInterfaceName(interfaceName)
+            val addDnsServer = LinkProperties::class.java
+                .getMethod("addDnsServer", InetAddress::class.java)
+            dnsServers.forEach { addDnsServer.invoke(this, it) }
+        }
+        if (setupWithLinkProperties(owner, instance, properties to binder)) return
+
         val method = owner.getMethod("setupTestNetwork", String::class.java, IBinder::class.java)
         method.invoke(instance, interfaceName, binder)
     }
+
+    private fun setupWithLinkProperties(
+        owner: Class<*>,
+        instance: Any,
+        request: Pair<LinkProperties, IBinder>,
+    ): Boolean = runCatching {
+        val method = owner.getMethod(
+            "setupTestNetwork",
+            LinkProperties::class.java,
+            Boolean::class.javaPrimitiveType,
+            IBinder::class.java,
+        )
+        method.invoke(instance, request.first, true, request.second)
+    }.isSuccess
 
     /** Tears down the framework-side test network for [network]. */
     fun teardownTestNetwork(network: Network) {

--- a/app/src/main/java/dev/shizzi/ProbeRunner.kt
+++ b/app/src/main/java/dev/shizzi/ProbeRunner.kt
@@ -97,7 +97,7 @@ class ProbeRunner(private val context: Context) {
         if (attemptTethering) restartDownstreamBeforeTun(report)
 
         val acquired = runCatching {
-            group.acquire(tunAddresses(), availabilityTimeoutMs)
+            group.acquire(tunAddresses(), TEST_NETWORK_DNS_SERVERS, availabilityTimeoutMs)
         }
 
         acquired.fold(
@@ -529,6 +529,7 @@ class ProbeRunner(private val context: Context) {
         /** The IPv6 counterpart, from the documentation range so it cannot collide. */
         const val TUN_ADDRESS_V6 = "2001:db8::2"
         const val TUN_PREFIX_LENGTH_V6 = 64
+
 
         /**
          * Link MTU for the TUN (R5.5 default). Egress is direct rather than

--- a/app/src/main/java/dev/shizzi/ProbeRunner.kt
+++ b/app/src/main/java/dev/shizzi/ProbeRunner.kt
@@ -97,7 +97,7 @@ class ProbeRunner(private val context: Context) {
         if (attemptTethering) restartDownstreamBeforeTun(report)
 
         val acquired = runCatching {
-            group.acquire(tunAddress(), availabilityTimeoutMs)
+            group.acquire(tunAddresses(), availabilityTimeoutMs)
         }
 
         acquired.fold(
@@ -503,8 +503,10 @@ class ProbeRunner(private val context: Context) {
         ).forEach { (id, question) -> report.recordSkip(id, question, reason) }
     }
 
-    private fun tunAddress(): LinkAddress =
-        buildLinkAddress(InetAddress.getByName(TUN_ADDRESS), TUN_PREFIX_LENGTH)
+    private fun tunAddresses(): List<LinkAddress> = listOf(
+        buildLinkAddress(InetAddress.getByName(TUN_ADDRESS), TUN_PREFIX_LENGTH),
+        buildLinkAddress(InetAddress.getByName(TUN_ADDRESS_V6), TUN_PREFIX_LENGTH_V6),
+    )
 
     private fun environment(): JSONObject = JSONObject().apply {
         put("device", "${Build.MANUFACTURER} ${Build.MODEL}")
@@ -523,6 +525,10 @@ class ProbeRunner(private val context: Context) {
         /** TEST-NET-1 per spec R3.2. */
         const val TUN_ADDRESS = "192.0.2.2"
         const val TUN_PREFIX_LENGTH = 24
+
+        /** The IPv6 counterpart, from the documentation range so it cannot collide. */
+        const val TUN_ADDRESS_V6 = "2001:db8::2"
+        const val TUN_PREFIX_LENGTH_V6 = 64
 
         /**
          * Link MTU for the TUN (R5.5 default). Egress is direct rather than

--- a/app/src/main/java/dev/shizzi/SessionResources.kt
+++ b/app/src/main/java/dev/shizzi/SessionResources.kt
@@ -42,8 +42,8 @@ class SessionResources(
      *   engineering guideline on error messages. Callers must call [release] on
      *   failure; partial state is never left implicitly owned.
      */
-    fun acquire(address: android.net.LinkAddress, availabilityTimeoutMs: Int): String {
-        val created = testNetworkApi.createTunInterface(address)
+    fun acquire(addresses: List<android.net.LinkAddress>, availabilityTimeoutMs: Int): String {
+        val created = testNetworkApi.createTunInterface(addresses)
         tun = created
         fileDescriptor = created.fileDescriptor
 

--- a/app/src/main/java/dev/shizzi/SessionResources.kt
+++ b/app/src/main/java/dev/shizzi/SessionResources.kt
@@ -42,13 +42,17 @@ class SessionResources(
      *   engineering guideline on error messages. Callers must call [release] on
      *   failure; partial state is never left implicitly owned.
      */
-    fun acquire(addresses: List<android.net.LinkAddress>, availabilityTimeoutMs: Int): String {
+    fun acquire(
+        addresses: List<android.net.LinkAddress>,
+        dnsServers: List<java.net.InetAddress>,
+        availabilityTimeoutMs: Int,
+    ): String {
         val created = testNetworkApi.createTunInterface(addresses)
         tun = created
         fileDescriptor = created.fileDescriptor
 
         val name = created.interfaceName
-        testNetworkApi.setupTestNetwork(name, lifetimeToken)
+        testNetworkApi.setupTestNetwork(name, dnsServers, lifetimeToken)
 
         network = awaitAvailability(name, availabilityTimeoutMs)
         requestKeepAlive()

--- a/app/src/main/java/dev/shizzi/TetherSession.kt
+++ b/app/src/main/java/dev/shizzi/TetherSession.kt
@@ -75,7 +75,7 @@ class TetherSession(private val context: Context) {
         val group = SessionResources(testNetworkApi, context.connectivityManager())
         resources = group
 
-        val name = group.acquire(tunAddresses(), AVAILABILITY_TIMEOUT_MS)
+        val name = group.acquire(tunAddresses(), TEST_NETWORK_DNS_SERVERS, AVAILABILITY_TIMEOUT_MS)
         interfaceName = name
         SessionLog.info("tun up: $name")
 
@@ -358,6 +358,7 @@ class TetherSession(private val context: Context) {
         /** The IPv6 counterpart, from the documentation range so it cannot collide. */
         const val TUN_ADDRESS_V6 = "2001:db8::2"
         const val TUN_PREFIX_LENGTH_V6 = 64
+
         const val TUN_MTU = 1500
         const val AVAILABILITY_TIMEOUT_MS = 10_000
         const val UPSTREAM_SETTLE_MS = 8_000L

--- a/app/src/main/java/dev/shizzi/TetherSession.kt
+++ b/app/src/main/java/dev/shizzi/TetherSession.kt
@@ -75,7 +75,7 @@ class TetherSession(private val context: Context) {
         val group = SessionResources(testNetworkApi, context.connectivityManager())
         resources = group
 
-        val name = group.acquire(tunAddress(), AVAILABILITY_TIMEOUT_MS)
+        val name = group.acquire(tunAddresses(), AVAILABILITY_TIMEOUT_MS)
         interfaceName = name
         SessionLog.info("tun up: $name")
 
@@ -345,13 +345,19 @@ class TetherSession(private val context: Context) {
         put("interface", interfaceName ?: JSONObject.NULL)
     }.toString()
 
-    private fun tunAddress() =
-        buildLinkAddress(java.net.InetAddress.getByName(TUN_ADDRESS), TUN_PREFIX_LENGTH)
+    private fun tunAddresses() = listOf(
+        buildLinkAddress(java.net.InetAddress.getByName(TUN_ADDRESS), TUN_PREFIX_LENGTH),
+        buildLinkAddress(java.net.InetAddress.getByName(TUN_ADDRESS_V6), TUN_PREFIX_LENGTH_V6),
+    )
 
     private companion object {
         const val TAG = "TetherSession"
         const val TUN_ADDRESS = "192.0.2.2"
         const val TUN_PREFIX_LENGTH = 24
+
+        /** The IPv6 counterpart, from the documentation range so it cannot collide. */
+        const val TUN_ADDRESS_V6 = "2001:db8::2"
+        const val TUN_PREFIX_LENGTH_V6 = 64
         const val TUN_MTU = 1500
         const val AVAILABILITY_TIMEOUT_MS = 10_000
         const val UPSTREAM_SETTLE_MS = 8_000L

--- a/datapath/datapath.go
+++ b/datapath/datapath.go
@@ -11,9 +11,12 @@ import (
 	"net"
 
 	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/link/fdbased"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/icmp"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
 	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
 )
@@ -38,9 +41,20 @@ type Session struct {
 //
 // mtu is the link MTU of the TUN interface.
 func Start(tunFD int, mtu int) (*Session, error) {
+	// ICMP is registered for both families so the stack can answer and relay
+	// errors. IPv6 in particular cannot fragment in flight, so a client only
+	// learns a path MTU from the ICMPv6 Packet Too Big it gets back.
 	netStack := stack.New(stack.Options{
-		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol},
-		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol, udp.NewProtocol},
+		NetworkProtocols: []stack.NetworkProtocolFactory{
+			ipv4.NewProtocol,
+			ipv6.NewProtocol,
+		},
+		TransportProtocols: []stack.TransportProtocolFactory{
+			tcp.NewProtocol,
+			udp.NewProtocol,
+			icmp.NewProtocol4,
+			icmp.NewProtocol6,
+		},
 	})
 
 	endpoint, err := fdbased.New(&fdbased.Options{
@@ -62,7 +76,10 @@ func Start(tunFD int, mtu int) (*Session, error) {
 	netStack.SetPromiscuousMode(nicID, true)
 	netStack.SetSpoofing(nicID, true)
 
-	netStack.SetRouteTable([]tcpip.Route{{Destination: header4Subnet(), NIC: nicID}})
+	netStack.SetRouteTable([]tcpip.Route{
+		{Destination: header.IPv4EmptySubnet, NIC: nicID},
+		{Destination: header.IPv6EmptySubnet, NIC: nicID},
+	})
 
 	installForwarders(netStack, &net.Dialer{Timeout: dialTimeout})
 
@@ -76,16 +93,4 @@ func (s *Session) Stop() {
 	}
 	s.stack.Close()
 	s.stack = nil
-}
-
-// header4Subnet returns the 0.0.0.0/0 subnet used as the default route.
-func header4Subnet() tcpip.Subnet {
-	subnet, err := tcpip.NewSubnet(
-		tcpip.AddrFrom4([4]byte{0, 0, 0, 0}),
-		tcpip.MaskFromBytes([]byte{0, 0, 0, 0}),
-	)
-	if err != nil {
-		panic(fmt.Sprintf("datapath: default IPv4 subnet is invalid: %v", err))
-	}
-	return subnet
 }

--- a/datapath/datapath_test.go
+++ b/datapath/datapath_test.go
@@ -1,0 +1,110 @@
+package datapath
+
+import (
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
+)
+
+const (
+	testQueueDepth = 16
+	testMTU        = 1500
+)
+
+// newTestStack mirrors the stack Start builds, over a channel endpoint rather
+// than the fd-backed one, which needs a real TUN. Kept in step with Start by
+// hand: the protocol set and route table below must match it.
+func newTestStack(t *testing.T) *stack.Stack {
+	t.Helper()
+
+	netStack := stack.New(stack.Options{
+		NetworkProtocols: []stack.NetworkProtocolFactory{
+			ipv4.NewProtocol,
+			ipv6.NewProtocol,
+		},
+		TransportProtocols: []stack.TransportProtocolFactory{
+			tcp.NewProtocol,
+			udp.NewProtocol,
+		},
+	})
+	t.Cleanup(netStack.Close)
+
+	if err := netStack.CreateNIC(nicID, channel.New(testQueueDepth, testMTU, "")); err != nil {
+		t.Fatalf("CreateNIC: %v", err)
+	}
+	netStack.SetRouteTable([]tcpip.Route{
+		{Destination: header.IPv4EmptySubnet, NIC: nicID},
+		{Destination: header.IPv6EmptySubnet, NIC: nicID},
+	})
+
+	// The TUN's own addresses, which the framework assigns on the real device;
+	// a route needs a source address on the NIC to be selectable.
+	for _, address := range []tcpip.ProtocolAddress{tunAddress4(), tunAddress6()} {
+		if err := netStack.AddProtocolAddress(nicID, address, stack.AddressProperties{}); err != nil {
+			t.Fatalf("AddProtocolAddress %v: %v", address.AddressWithPrefix, err)
+		}
+	}
+	return netStack
+}
+
+func tunAddress4() tcpip.ProtocolAddress {
+	return tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddrFrom4([4]byte{192, 0, 2, 2}).
+			WithPrefix(),
+	}
+}
+
+func tunAddress6() tcpip.ProtocolAddress {
+	return tcpip.ProtocolAddress{
+		Protocol: ipv6.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddrFrom16([16]byte{
+			0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02,
+		}).WithPrefix(),
+	}
+}
+
+// TestStackRoutesBothFamilies is the regression test for #5: an IPv6-addressed
+// flow must find a route. Before IPv6 was registered, FindRoute returned
+// ErrNetworkUnreachable and every v6 packet off the TUN was dropped.
+func TestStackRoutesBothFamilies(t *testing.T) {
+	netStack := newTestStack(t)
+	netStack.SetPromiscuousMode(nicID, true)
+	netStack.SetSpoofing(nicID, true)
+
+	tests := []struct {
+		name     string
+		protocol tcpip.NetworkProtocolNumber
+		address  tcpip.Address
+	}{
+		{
+			name:     "IPv4",
+			protocol: ipv4.ProtocolNumber,
+			address:  tcpip.AddrFrom4([4]byte{192, 0, 2, 1}),
+		},
+		{
+			name:     "IPv6",
+			protocol: ipv6.ProtocolNumber,
+			address: tcpip.AddrFrom16([16]byte{
+				0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
+			}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			route, err := netStack.FindRoute(nicID, tcpip.Address{}, test.address, test.protocol, false)
+			if err != nil {
+				t.Fatalf("FindRoute to %v: %v", test.address, err)
+			}
+			route.Release()
+		})
+	}
+}


### PR DESCRIPTION
Closes #5.

Adds support for IPv6 throughout the system.

- Register `ipv6` and ICMP for both families in the gVisor stack; route `::/0` alongside `0.0.0.0/0`.
- Give the TUN an IPv6 address, which required widening `createTunInterface` to the `Collection` overload the platform already accepts.
- Register the test network through `setupTestNetwork(LinkProperties, boolean, IBinder)` carrying DNS servers.

The datapath registered only `ipv4.NewProtocol`, so IPv6 frames off the TUN were discarded as an unknown network protocol. Clients still saw a v6 default route from the tethering stack, preferred it, and got nothing.

Adding v6 to the datapath alone was not enough. `TetheringInterfaceUtils.getIPv6Interface` requires `hasIpv6DnsServer()`, and the `(String, IBinder)` overload we used registers the network with no DNS servers — so `IPv6TetheringCoordinator` recorded `UpstreamNetworkState{null}` and never provisioned IPv6 downstream.

## Verification

Pixel 10a, tethered client:

- `IPv6TetheringCoordinator` moves from `UpstreamNetworkState{null}` to a populated state.
- `wlan1` gains a global `2001:db8::/64` address; BPF shows IPv6 forwarding rules from the TUN to the downstream.
- Client reaches the IPv6 internet.
- With a VPN that carries no v6 (Surfshark), the client gets no v6 rather than leaking around the tunnel.

`datapath/datapath_test.go` asserts both families route; it fails with `unknown protocol` on IPv6 against the pre-fix stack. Requires Linux — `fdbased` does not build on darwin.

Untested: IPv6 through an IPv6-compatible VPN.