### PR TITLE
VPN tethering: surface it in the UI and handle VPN loss

### DIFF
--- a/app/src/main/aidl/dev/shizzi/ITetherService.aidl
+++ b/app/src/main/aidl/dev/shizzi/ITetherService.aidl
@@ -31,8 +31,10 @@ interface ITetherService {
     /**
      * Current session state as JSON, without changing anything.
      *
-     * Cheap enough to poll: it reports what this process holds and does not
-     * shell out to dumpsys.
+     * Cheap enough to poll every second. Most of what it reports is held by
+     * this process or read from /proc, and the one field that needs a dumpsys
+     * — the count of associated devices — is rate-limited behind its own
+     * refresh interval rather than read per call.
      */
     String getStatus();
 

--- a/app/src/main/java/dev/shizzi/DownstreamInspector.kt
+++ b/app/src/main/java/dev/shizzi/DownstreamInspector.kt
@@ -12,6 +12,9 @@ package dev.shizzi
  */
 class DownstreamInspector(private val inspector: UpstreamInspector = UpstreamInspector()) {
 
+    private var cachedCount = 0
+    private var lastReadAt = 0L
+
     /** @return null when nothing is tethered, else what is still up. */
     fun findTetheredDownstream(): String? {
         val observation = inspector.observe()
@@ -28,6 +31,56 @@ class DownstreamInspector(private val inspector: UpstreamInspector = UpstreamIns
         }
     }
 
+    /**
+     * How many devices are on the hotspot.
+     *
+     * Rate-limited rather than read every call. The dump costs ~127ms of
+     * subprocess on device and status is polled continuously, so refreshing it
+     * on every tick would spend most of a session's polling budget on a number
+     * that changes when someone walks into the room. Between refreshes the last
+     * reading stands.
+     *
+     * Bytes deliberately do not come from here — [InterfaceCounters] reads them
+     * from the kernel in process, which is what lets the visible numbers move
+     * at a useful rate.
+     *
+     * @return 0 when nothing is tethered or the dump could not be read. A
+     *   failure reads the same as an idle hotspot: this feeds a display, and an
+     *   unreadable dump is not worth failing a session over.
+     */
+    fun countDevices(): Int {
+        val now = System.currentTimeMillis()
+        if (now - lastReadAt < REFRESH_INTERVAL_MS) return cachedCount
+
+        val observation = inspector.observeWifi()
+        if (observation.didTimeout) return cachedCount
+
+        lastReadAt = now
+        cachedCount = parseDeviceCount(observation.rawOutput)
+        return cachedCount
+    }
+
+    /**
+     * Devices currently associated with the hotspot.
+     *
+     * Read from `dumpsys wifi`, not `dumpsys tethering`. Both of tethering's
+     * candidate structures describe the past: the NAT forwarding rules keep
+     * entries for minutes after a device leaves (observed at 176s), and the
+     * "Client Information:" block is a DHCP lease list, which also still names
+     * a device that has gone. UpstreamInspector's own notes warn about exactly
+     * this — rule tables "describe what was, not what is".
+     *
+     * The Wi-Fi layer is where association is actually known, and it reports a
+     * live count that returned to 0 the moment a test device disconnected.
+     *
+     * @return 0 when nothing is connected or the dump could not be read.
+     */
+    private fun parseDeviceCount(output: String): Int =
+        CONNECTED_CLIENTS_PATTERN.findAll(output)
+            .mapNotNull { match -> match.groupValues[1].toIntOrNull() }
+            .maxOrNull()
+            ?: 0
+
     private companion object {
         /**
          * The live per-interface state line, e.g.
@@ -39,5 +92,28 @@ class DownstreamInspector(private val inspector: UpstreamInspector = UpstreamIns
          */
         private val TETHERED_STATE_PATTERN =
             Regex("""^\s*(\w+)\s+-\s+TetheredState\s+-""")
+
+        /**
+         * The SoftAP's live association count, e.g.
+         * "getConnectedClientList().size(): 0".
+         *
+         * Current state rather than one of the `num_connected_clients=` lines
+         * further down, which are a timestamped event history: reading those
+         * means reading whichever transition happened to be printed last.
+         *
+         * A device serving more than one AP instance prints this once each, so
+         * the largest is taken rather than the first.
+         */
+        private val CONNECTED_CLIENTS_PATTERN =
+            Regex("""getConnectedClientList\(\)\.size\(\):\s*(\d+)""")
+
+        /**
+         * How stale a device count may be.
+         *
+         * A device joining or leaving is not urgent to reflect — it is visible
+         * to the person holding the device either way — and this is the cost
+         * that keeps the poll cheap.
+         */
+        private const val REFRESH_INTERVAL_MS = 10_000L
     }
 }

--- a/app/src/main/java/dev/shizzi/InterfaceCounters.kt
+++ b/app/src/main/java/dev/shizzi/InterfaceCounters.kt
@@ -1,0 +1,56 @@
+package dev.shizzi
+
+import java.io.File
+
+/**
+ * Reads an interface's byte counters straight from the kernel.
+ *
+ * Exists to keep the byte half of a status read off `dumpsys`. Measured on
+ * device, spawning a subprocess costs ~127ms — of which ~75ms is fork/exec
+ * alone — and status is polled for the life of a session. Reading this file in
+ * process is a few hundred microseconds, which is what makes a fast refresh
+ * affordable at all.
+ *
+ * The counters are the same ones the tethering BPF stats report: sampled
+ * together across a 52 MB transfer, the TUN's rx and ForwardedStats' rxb
+ * tracked each other to within a few kilobytes.
+ */
+object InterfaceCounters {
+
+    /**
+     * @param interfaceName the session's own TUN. Named rather than matched by
+     *   prefix because a stale TUN from an earlier session can still be present
+     *   — a device showed testtun24 alongside the live testtun25 — and summing
+     *   both would report traffic the current session never carried.
+     *
+     * @return zeroes when the interface is absent, which is the honest reading
+     *   for a session that has not built its TUN yet.
+     */
+    fun read(interfaceName: String): Traffic {
+        val line = runCatching { File(PROC_NET_DEV).readLines() }
+            .getOrDefault(emptyList())
+            .firstOrNull { it.trimStart().startsWith("$interfaceName:") }
+            ?: return Traffic()
+
+        // "testtun25: 41573895 37687 0 ..." — the name and its colon run
+        // together when the counter is wide enough to fill the column, so the
+        // split is on the colon rather than on whitespace.
+        val fields = line.substringAfter(':').trim().split(WHITESPACE)
+        if (fields.size <= TX_BYTES_FIELD) return Traffic()
+
+        return Traffic(
+            // Receive and transmit are named from the interface's point of
+            // view, which inverts the user's: bytes the TUN received are bytes
+            // the tethered device downloaded.
+            down = fields[RX_BYTES_FIELD].toLongOrNull() ?: 0,
+            up = fields[TX_BYTES_FIELD].toLongOrNull() ?: 0,
+        )
+    }
+
+    private val WHITESPACE = Regex("""\s+""")
+    private const val PROC_NET_DEV = "/proc/net/dev"
+
+    /** Field order is fixed by the kernel: rx bytes first, tx bytes ninth. */
+    private const val RX_BYTES_FIELD = 0
+    private const val TX_BYTES_FIELD = 8
+}

--- a/app/src/main/java/dev/shizzi/SessionNotification.kt
+++ b/app/src/main/java/dev/shizzi/SessionNotification.kt
@@ -1,0 +1,134 @@
+package dev.shizzi
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+
+/**
+ * Builds the notification a running session posts.
+ *
+ * Split from SessionService so the wording lives in one readable place rather
+ * than interleaved with the concurrency the service exists to manage.
+ *
+ * The register throughout is the user's: a hotspot they are sharing, not a
+ * tunnel, a test network, or an interface name. Those are ours, and they are
+ * already in the log for anyone filing a bug.
+ */
+class SessionNotification(private val context: Context) {
+
+    fun build(state: SessionUiState, isStopping: Boolean): Notification {
+        createChannel()
+
+        val text = bodyFor(state, isStopping)
+
+        return Notification.Builder(context, CHANNEL_ID)
+            .setContentTitle(titleFor(state.status, isStopping))
+            .setContentText(text)
+            .setStyle(Notification.BigTextStyle().bigText(text))
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentIntent(openAppIntent())
+            .setOngoing(state.status != UiStatus.ERROR)
+            .addAction(stopAction())
+            .build()
+    }
+
+    /**
+     * [isStopping] disambiguates LOADING, which covers both directions.
+     *
+     * Deliberately no longer says "protected". That claimed a security property
+     * the app does not deliver: with no VPN up, traffic leaves over the physical
+     * network exactly as ordinary tethering would, and the only thing the word
+     * ever referred to was an implementation detail. Whether traffic is actually
+     * tunnelled is now stated in the body, and only when it is true.
+     *
+     * ERROR and READY share a title because the fact is the same in both — the
+     * session is over. Which of the two it was is what the body carries.
+     */
+    private fun titleFor(status: UiStatus, isStopping: Boolean): String = when (status) {
+        UiStatus.CONNECTED -> "Sharing this connection"
+        UiStatus.LOADING -> if (isStopping) "Ending the session…" else "Starting the session…"
+        UiStatus.ERROR -> "Session ended"
+        UiStatus.READY -> "Session ended"
+    }
+
+    /**
+     * What the notification says under its title.
+     *
+     * An error outranks everything: it is the only text here a user may need to
+     * act on. Otherwise a live session describes the path its clients' traffic
+     * takes, which is the one thing the notification can say that the screen
+     * cannot, since this is what stays visible with the app closed.
+     */
+    private fun bodyFor(state: SessionUiState, isStopping: Boolean): String = when {
+        state.lastError.isNotEmpty() -> state.lastError
+        state.status == UiStatus.LOADING -> loadingBody(isStopping)
+        state.status == UiStatus.CONNECTED -> connectedBody(state.isVpnBound)
+        else -> state.detail
+    }
+
+    private fun loadingBody(isStopping: Boolean): String =
+        if (isStopping) "Turning the hotspot off…" else "Turning the hotspot on…"
+
+    /**
+     * The absence of a VPN is stated, not merely left unsaid.
+     *
+     * Saying nothing is what lets someone who normally runs a VPN assume it is
+     * carrying their clients' traffic when it is not — the same silent fallback
+     * the watchdogs exist to prevent, in wording rather than in routing. Naming
+     * it costs one clause.
+     */
+    private fun connectedBody(isVpnBound: Boolean): String = when {
+        isVpnBound -> "Connected devices are going out through your VPN."
+        else -> "Connected devices are going out through this phone's network, not a VPN."
+    }
+
+    /** Phrased as what happened and what to do, not as a return value. */
+    fun describeLoss(problem: String?): String = when (problem) {
+        null -> "Shizuku stopped, so the session ended. The hotspot was turned off. " +
+            "Start again when you are ready."
+
+        else -> "The session ended but the hotspot may still be on: $problem — " +
+            "turn it off in Settings."
+    }
+
+    private fun openAppIntent(): PendingIntent = PendingIntent.getActivity(
+        context,
+        0,
+        Intent(context, MainActivity::class.java),
+        PendingIntent.FLAG_IMMUTABLE,
+    )
+
+    private fun stopAction(): Notification.Action = Notification.Action.Builder(
+        null,
+        "Stop",
+        PendingIntent.getService(
+            context,
+            1,
+            Intent(context, SessionService::class.java).setAction(SessionService.ACTION_STOP),
+            PendingIntent.FLAG_IMMUTABLE,
+        ),
+    ).build()
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Tethering session",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply { description = "Shown while a tethering session is running" }
+
+        notificationManager().createNotificationChannel(channel)
+    }
+
+    private fun notificationManager(): NotificationManager =
+        context.getSystemService(NotificationManager::class.java)
+
+    private companion object {
+        const val CHANNEL_ID = "tethering-session"
+    }
+}

--- a/app/src/main/java/dev/shizzi/SessionNotification.kt
+++ b/app/src/main/java/dev/shizzi/SessionNotification.kt
@@ -26,7 +26,7 @@ class SessionNotification(private val context: Context) {
         val text = bodyFor(state, isStopping)
 
         return Notification.Builder(context, CHANNEL_ID)
-            .setContentTitle(titleFor(state.status, isStopping))
+            .setContentTitle(titleFor(state, isStopping))
             .setContentText(text)
             .setStyle(Notification.BigTextStyle().bigText(text))
             .setSmallIcon(android.R.drawable.ic_dialog_info)
@@ -42,48 +42,91 @@ class SessionNotification(private val context: Context) {
      * Deliberately no longer says "protected". That claimed a security property
      * the app does not deliver: with no VPN up, traffic leaves over the physical
      * network exactly as ordinary tethering would, and the only thing the word
-     * ever referred to was an implementation detail. Whether traffic is actually
-     * tunnelled is now stated in the body, and only when it is true.
+     * ever referred to was an implementation detail.
      *
      * ERROR and READY share a title because the fact is the same in both — the
      * session is over. Which of the two it was is what the body carries.
      */
-    private fun titleFor(status: UiStatus, isStopping: Boolean): String = when (status) {
-        UiStatus.CONNECTED -> "Sharing this connection"
-        UiStatus.LOADING -> if (isStopping) "Ending the session…" else "Starting the session…"
-        UiStatus.ERROR -> "Session ended"
-        UiStatus.READY -> "Session ended"
+    private fun titleFor(state: SessionUiState, isStopping: Boolean): String =
+        when (state.status) {
+            UiStatus.CONNECTED -> connectedTitle(state.isVpnBound)
+            UiStatus.LOADING -> if (isStopping) "Cleaning up…" else "Getting ready…"
+            UiStatus.ERROR -> "Session ended"
+            UiStatus.READY -> "Session ended"
+        }
+
+    /**
+     * The VPN fact rides in the title, where a collapsed notification shows it.
+     *
+     * Its absence is not stated. "Connected" alone is the honest reading of
+     * ordinary tethering, and a notification that announces what is *not*
+     * happening spends the one line it has on a non-event.
+     */
+    private fun connectedTitle(isVpnBound: Boolean): String = when {
+        isVpnBound -> "Connected · VPN"
+        else -> "Connected"
     }
 
     /**
      * What the notification says under its title.
      *
      * An error outranks everything: it is the only text here a user may need to
-     * act on. Otherwise a live session describes the path its clients' traffic
-     * takes, which is the one thing the notification can say that the screen
-     * cannot, since this is what stays visible with the app closed.
+     * act on.
+     *
+     * Nothing reaches this that was not written for a user to read. The former
+     * fallthrough handed [SessionUiState.detail] over verbatim, which put
+     * "tethered clients routing through testtun47" — and, on a failed start, a
+     * raw exception class name — on a notification. Both are diagnostics; they
+     * stay in the log and the in-app toast, which is where someone filing a bug
+     * looks for them.
      */
     private fun bodyFor(state: SessionUiState, isStopping: Boolean): String = when {
-        state.lastError.isNotEmpty() -> state.lastError
+        state.lastError.isNotEmpty() -> userFacingError(state.lastError)
         state.status == UiStatus.LOADING -> loadingBody(isStopping)
-        state.status == UiStatus.CONNECTED -> connectedBody(state.isVpnBound)
-        else -> state.detail
+        state.status == UiStatus.CONNECTED -> connectedBody(state)
+        else -> "Not sharing"
+    }
+
+    /**
+     * @return [raw] when it was written for a user, else a plain stand-in.
+     *
+     * A stack-trace fragment tells the user nothing they can act on and reads
+     * as a crash. The detail survives in the log either way, so the notification
+     * loses nothing by declining to show it.
+     */
+    private fun userFacingError(raw: String): String = when {
+        raw.contains(EXCEPTION_MARKER) -> "Something went wrong. Check the app for details."
+        else -> raw
     }
 
     private fun loadingBody(isStopping: Boolean): String =
         if (isStopping) "Turning the hotspot off…" else "Turning the hotspot on…"
 
     /**
-     * The absence of a VPN is stated, not merely left unsaid.
+     * What is actually happening: how many devices, and how much has moved.
      *
-     * Saying nothing is what lets someone who normally runs a VPN assume it is
-     * carrying their clients' traffic when it is not — the same silent fallback
-     * the watchdogs exist to prevent, in wording rather than in routing. Naming
-     * it costs one clause.
+     * The body carries information rather than a longer restatement of the
+     * title. It is also the half a user keeps looking at, since the counts are
+     * the only thing on the notification that changes while a session runs.
+     *
+     * Before any device connects there is nothing to count, and "0 devices ·
+     * ↓ 0 B" reads as a fault rather than as an empty hotspot, so that case is
+     * stated plainly instead.
+     *
+     * No terminal period on any of these: they are fragments, and a stop after
+     * a phrase that is not a sentence reads as a typo. The full sentences below
+     * — the ones telling a user what to do — keep theirs.
      */
-    private fun connectedBody(isVpnBound: Boolean): String = when {
-        isVpnBound -> "Connected devices are going out through your VPN."
-        else -> "Connected devices are going out through this phone's network, not a VPN."
+    private fun connectedBody(state: SessionUiState): String = when (state.clientCount) {
+        0 -> "No devices connected"
+        else -> "${deviceCount(state.clientCount)} · " +
+            "$DOWN_ARROW ${Traffic.format(state.traffic.down)} · " +
+            "$UP_ARROW ${Traffic.format(state.traffic.up)}"
+    }
+
+    private fun deviceCount(clients: Int): String = when (clients) {
+        1 -> "1 device"
+        else -> "$clients devices"
     }
 
     /** Phrased as what happened and what to do, not as a return value. */
@@ -130,5 +173,19 @@ class SessionNotification(private val context: Context) {
 
     private companion object {
         const val CHANNEL_ID = "tethering-session"
+
+        /** How a Kotlin exception name reads once it reaches a UI string. */
+        const val EXCEPTION_MARKER = "Exception"
+
+        /**
+         * Plain arrows, not the emoji ones.
+         *
+         * U+2193/U+2191 render in the notification's own text font at the
+         * weight of the digits beside them. The emoji variants would be
+         * substituted from the colour font and sit as coloured blobs against
+         * monochrome text.
+         */
+        const val DOWN_ARROW = "\u2193"
+        const val UP_ARROW = "\u2191"
     }
 }

--- a/app/src/main/java/dev/shizzi/SessionResources.kt
+++ b/app/src/main/java/dev/shizzi/SessionResources.kt
@@ -117,6 +117,22 @@ class SessionResources(
     }
 
     /**
+     * Pins the datapath's upstream sockets to [handle], or unbinds at 0.
+     *
+     * Lives here because the datapath session is one of the four things this
+     * class owns and nothing outside it holds a reference.
+     *
+     * @throws IllegalStateException if there is no datapath to bind, which
+     *   means acquire and startDatapath have not both succeeded.
+     */
+    fun bindDatapathTo(handle: Long) {
+        val session = datapathSession
+            ?: error("bindDatapathTo($handle): no datapath session; startDatapath must succeed first")
+
+        session.setNetwork(handle)
+    }
+
+    /**
      * Waits for the test network matching [interfaceName] to become available.
      *
      * R3.3 makes the timeout a hard failure: returning without a Network would

--- a/app/src/main/java/dev/shizzi/SessionService.kt
+++ b/app/src/main/java/dev/shizzi/SessionService.kt
@@ -41,6 +41,8 @@ class SessionService : Service() {
 
     private val scope = CoroutineScope(SupervisorJob())
     private val controller = TetherClient()
+    private val notification by lazy { SessionNotification(this) }
+    private val statusPoller = SessionStatusPoller(scope, controller)
 
     /** The companion's flow, so the UI sees updates from before onCreate ran. */
     private val internalState get() = sessionState
@@ -109,10 +111,9 @@ class SessionService : Service() {
         isStopping = intent?.action == ACTION_STOP
         startForeground(
             NOTIFICATION_ID,
-            buildNotification(
-                status = UiStatus.LOADING,
-                text = if (isStopping) "Dropping the hotspot…" else "Bringing the tunnel up…",
-                isStopping = isStopping,
+            notification.build(
+                SessionUiState(status = UiStatus.LOADING),
+                isStopping,
             ),
         )
 
@@ -149,8 +150,17 @@ class SessionService : Service() {
 
             internalState.update { current -> current.applyOutcome(outcome) }
             publishState()
+            followStatus()
         }
     }
+
+    private fun followStatus() = statusPoller.follow(
+        isConnected = { internalState.value.status == UiStatus.CONNECTED },
+        onStatus = { outcome ->
+            internalState.update { current -> current.applyOutcome(outcome) }
+            publishState()
+        },
+    )
 
     private fun settingsStore(): SettingsStore =
         (application as App).settingsStore
@@ -182,9 +192,15 @@ class SessionService : Service() {
         val abandoned = startJob
         startJob = null
 
+        statusPoller.stop()
+
         internalState.update {
             it.asStopped()
         }
+        // Without this the notification sits on the text onStartCommand posted
+        // for the whole teardown, which outlasts a cancelAndJoin plus a full
+        // privileged release.
+        publishState()
 
         scope.launch {
             // Abandon an in-flight start first, and wait for it to actually
@@ -227,6 +243,8 @@ class SessionService : Service() {
      * clients still attached.
      */
     private fun handleSessionLost() {
+        statusPoller.stop()
+
         // Not a user-initiated stop; the ERROR title applies, not "Stopping…".
         isStopping = false
         SessionLog.error("shell process died; recovering any downstream it left up")
@@ -250,89 +268,18 @@ class SessionService : Service() {
                 else -> SessionLog.error("orphan recovery failed: $problem")
             }
 
-            internalState.update { current -> current.copy(lastError = describeLoss(problem)) }
+            internalState.update { current -> current.copy(lastError = notification.describeLoss(problem)) }
             publishState()
             stopSelf()
         }
     }
 
-    private fun describeLoss(problem: String?): String = when (problem) {
-        null -> "Session ended: the Shizuku service stopped. " +
-            "The hotspot was turned off. Press Start to reconnect."
-
-        else -> "Session ended and the hotspot may still be on: $problem — " +
-            "turn it off in Settings."
-    }
-
     /** Mirrors the current state into the notification. */
     private fun publishState() {
-        val state = internalState.value
-        val text = when {
-            state.lastError.isNotEmpty() -> state.lastError
-            state.interfaceName.isNotEmpty() -> "Clients routing through ${state.interfaceName}"
-            else -> state.detail
-        }
-
         notificationManager().notify(
             NOTIFICATION_ID,
-            buildNotification(state.status, text, isStopping),
+            notification.build(internalState.value, isStopping),
         )
-    }
-
-    private fun buildNotification(
-        status: UiStatus,
-        text: String,
-        isStopping: Boolean = false,
-    ): Notification {
-        createChannel()
-
-        return Notification.Builder(this, CHANNEL_ID)
-            .setContentTitle(titleFor(status, isStopping))
-            .setContentText(text)
-            .setStyle(Notification.BigTextStyle().bigText(text))
-            .setSmallIcon(android.R.drawable.ic_dialog_info)
-            .setContentIntent(openAppIntent())
-            .setOngoing(status != UiStatus.ERROR)
-            .addAction(stopAction())
-            .build()
-    }
-
-    /** [isStopping] disambiguates LOADING, which covers both directions. */
-    private fun titleFor(status: UiStatus, isStopping: Boolean): String = when (status) {
-        UiStatus.CONNECTED -> "Tethering protected"
-        UiStatus.LOADING -> if (isStopping) "Stopping…" else "Starting…"
-        UiStatus.ERROR -> "Tethering stopped"
-        UiStatus.READY -> "Ready"
-    }
-
-    private fun openAppIntent(): PendingIntent = PendingIntent.getActivity(
-        this,
-        0,
-        Intent(this, MainActivity::class.java),
-        PendingIntent.FLAG_IMMUTABLE,
-    )
-
-    private fun stopAction(): Notification.Action = Notification.Action.Builder(
-        null,
-        "Stop",
-        PendingIntent.getService(
-            this,
-            1,
-            Intent(this, SessionService::class.java).setAction(ACTION_STOP),
-            PendingIntent.FLAG_IMMUTABLE,
-        ),
-    ).build()
-
-    private fun createChannel() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-
-        val channel = NotificationChannel(
-            CHANNEL_ID,
-            "Tethering session",
-            NotificationManager.IMPORTANCE_LOW,
-        ).apply { description = "Shown while a protected tethering session is active" }
-
-        notificationManager().createNotificationChannel(channel)
     }
 
     private fun notificationManager(): NotificationManager =
@@ -347,9 +294,8 @@ class SessionService : Service() {
     }
 
     companion object {
-        private const val CHANNEL_ID = "tethering-session"
         private const val NOTIFICATION_ID = 1
-        private const val ACTION_STOP = "dev.shizzi.STOP_SESSION"
+        const val ACTION_STOP = "dev.shizzi.STOP_SESSION"
 
         /**
          * Session state, for the UI to observe.

--- a/app/src/main/java/dev/shizzi/SessionStatusPoller.kt
+++ b/app/src/main/java/dev/shizzi/SessionStatusPoller.kt
@@ -54,7 +54,16 @@ class SessionStatusPoller(
     }
 
     private companion object {
-        /** Matches the shell-side watchdogs, so the UI lags them by at most one tick. */
-        const val POLL_INTERVAL_MS = 5_000L
+        /**
+         * Fast enough that the byte counters read as live rather than as
+         * steps.
+         *
+         * Affordable only because a status read no longer spawns a process:
+         * the counters come from /proc in process, and the device count behind
+         * it refreshes on its own slower schedule. At the previous design's
+         * ~127ms per read this rate would have burned ~13% of a core for the
+         * life of every session.
+         */
+        const val POLL_INTERVAL_MS = 1_000L
     }
 }

--- a/app/src/main/java/dev/shizzi/SessionStatusPoller.kt
+++ b/app/src/main/java/dev/shizzi/SessionStatusPoller.kt
@@ -1,0 +1,60 @@
+package dev.shizzi
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Mirrors the shell process's view of a live session into the app's.
+ *
+ * The privileged side has no way to push. It can adopt or lose a VPN long after
+ * the start call returned, and without this neither the badge nor the
+ * notification would ever hear about it — they would keep rendering whatever
+ * the last binder call happened to report. getStatus is documented as cheap
+ * enough to poll and reports only what that process already holds.
+ *
+ * Runs only while a session is connected. status() binds the user service if
+ * nothing is bound, so a poller left running past teardown would resurrect the
+ * shell process the user just stopped.
+ */
+class SessionStatusPoller(
+    private val scope: CoroutineScope,
+    private val controller: TetherClient,
+) {
+
+    private var job: Job? = null
+
+    /**
+     * Restarts polling if [isConnected] says a session is up, else stops.
+     *
+     * @param onStatus folds one reading in and is called only for a successful
+     *   read: a failed one is not a failed session — the shell process's own
+     *   watchdogs decide that — and repainting an error here would contradict a
+     *   session that is still running fine.
+     */
+    fun follow(isConnected: () -> Boolean, onStatus: (Result<String>) -> Unit) {
+        stop()
+        if (!isConnected()) return
+
+        job = scope.launch {
+            while (isConnected()) {
+                delay(POLL_INTERVAL_MS)
+                if (!isConnected()) return@launch
+
+                val outcome = runCatching { controller.status() }
+                if (outcome.isSuccess) onStatus(outcome)
+            }
+        }
+    }
+
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+
+    private companion object {
+        /** Matches the shell-side watchdogs, so the UI lags them by at most one tick. */
+        const val POLL_INTERVAL_MS = 5_000L
+    }
+}

--- a/app/src/main/java/dev/shizzi/SessionTeardown.kt
+++ b/app/src/main/java/dev/shizzi/SessionTeardown.kt
@@ -1,0 +1,128 @@
+package dev.shizzi
+
+import android.content.Context
+import android.util.Log
+
+/**
+ * Releases what a session holds outside its own resource group.
+ *
+ * Split from TetherSession so that class stays about the lifecycle it runs;
+ * this is the ordering-sensitive release of things the framework owns — the
+ * upstream selection, the downstream, and the shutdown hook that covers an
+ * abrupt process exit.
+ */
+class SessionTeardown(private val context: Context) {
+
+    private val inspector = UpstreamInspector()
+    private var shutdownHook: Thread? = null
+
+    /**
+     * Drops the downstream if this process exits through System.exit.
+     *
+     * Covers exactly one path: ShizukuServiceStarter calling System.exit when
+     * the server it depends on goes away. That is a real path — it is how the
+     * 13.5.4 crash took this process down — but it is the only one.
+     *
+     * ART does not unwind shutdown hooks on signal death, so SIGTERM and
+     * SIGKILL both bypass this entirely; a device test confirmed SIGTERM
+     * leaves the hotspot tethered with no hook output. Recovery for those
+     * cases lives in the app process, which outlives this one (see
+     * SessionViewModel's session-lost handling).
+     */
+    fun installShutdownHook() {
+        val hook = Thread {
+            Log.w(TAG, "process exiting with session active; dropping downstream")
+            runCatching { DownstreamControl(context).stopWifiTethering() }
+        }
+
+        runCatching { Runtime.getRuntime().addShutdownHook(hook) }
+            .onSuccess { shutdownHook = hook }
+            .onFailure { Log.w(TAG, "installShutdownHook: ${it.message}") }
+    }
+
+    fun removeShutdownHook() {
+        shutdownHook?.let { hook ->
+            // Throws if the JVM is already shutting down, which is exactly when
+            // the hook should stay installed.
+            runCatching { Runtime.getRuntime().removeShutdownHook(hook) }
+        }
+        shutdownHook = null
+    }
+
+    /**
+     * Hands the upstream back to the framework *before* the TUN is destroyed.
+     *
+     * This ordering is load-bearing. Destroying the interface first leaves
+     * tethering holding a reference it can no longer act on: its own teardown
+     * needs the interface to exist, so it logs
+     *
+     *     [BpfCoordinator] Could not detach program: Fail to get interface
+     *     params for interface testtunNN
+     *
+     * and keeps naming that dead interface as the current upstream. Every
+     * subsequent start then fails verifyUpstream against a ghost, permanently,
+     * with nothing the app can do about it afterward and no way for a user to
+     * clear it short of a reboot. A device test wedged a phone exactly this way
+     * for eleven consecutive sessions.
+     *
+     * So the preference is cleared while the TUN is still up, and this waits
+     * for tethering to actually move off it. The wait is bounded and best
+     * effort: if the framework has not let go by the deadline, destroying the
+     * interface is still better than leaking it, and the next start reselects
+     * from whatever remains.
+     */
+    fun releaseUpstreamSelection(interfaceName: String?) {
+        val cleared = runCatching { TetheringPreferenceApi(context).setPreferTestNetworks(false) }
+            .onFailure { Log.w(TAG, "stop: preference ${it.message}") }
+        if (cleared.isFailure) return
+
+        val name = interfaceName ?: return
+        val deadline = System.currentTimeMillis() + UPSTREAM_RELEASE_MS
+
+        while (System.currentTimeMillis() < deadline) {
+            val observed = runCatching { inspector.observe().interfaceNames }.getOrDefault(emptyList())
+            if (observed.none { it == name }) {
+                SessionLog.info("upstream released: tethering moved off $name")
+                return
+            }
+            Thread.sleep(UPSTREAM_POLL_MS)
+        }
+
+        SessionLog.warn("upstream still reads $name after ${UPSTREAM_RELEASE_MS}ms; releasing anyway")
+    }
+
+    /** @return null once no downstream is tethered, else what is still up. */
+    fun releaseDownstream(): String? {
+        val control = DownstreamControl(context)
+
+        val didAccept = runCatching { control.stopWifiTethering() }
+            .getOrElse { failure ->
+                Log.w(TAG, "stop: downstream ${failure.message}")
+                false
+            }
+
+        val stillTethered = runCatching { DownstreamInspector().findTetheredDownstream() }
+            .getOrElse { failure -> "could not verify downstream: ${failure.message}" }
+
+        return when {
+            stillTethered != null -> stillTethered
+            didAccept -> null
+            else -> "stopTethering was rejected, but no downstream remains tethered"
+        }
+    }
+
+    private companion object {
+        const val TAG = "SessionTeardown"
+        const val UPSTREAM_POLL_MS = 500L
+
+        /**
+         * How long teardown waits for tethering to release the owned TUN.
+         *
+         * Shorter than the settle deadline: this is the framework letting go of
+         * an interface rather than selecting and validating a new one, and the
+         * session is already on its way out. Exceeding it is logged and the
+         * interface destroyed regardless — leaking the TUN would be worse.
+         */
+        const val UPSTREAM_RELEASE_MS = 4_000L
+    }
+}

--- a/app/src/main/java/dev/shizzi/TetherClient.kt
+++ b/app/src/main/java/dev/shizzi/TetherClient.kt
@@ -21,6 +21,7 @@ data class SessionUiState(
     val detail: String = "",
     val interfaceName: String = "",
     val lastError: String = "",
+    val isVpnBound: Boolean = false,
 ) {
     /** Shizuku must be ready before the button can do anything. */
     val canStart: Boolean get() = shizukuState is ShizukuState.Ready && !isBusy
@@ -39,6 +40,7 @@ fun SessionUiState.asStopped(): SessionUiState = copy(
     lastError = "",
     detail = "Stopped",
     interfaceName = "",
+    isVpnBound = false,
 )
 
 /**
@@ -61,6 +63,9 @@ fun SessionUiState.applyOutcome(outcome: Result<String>): SessionUiState {
             // A failed start tears its TUN down on the way out, so keeping the
             // name would caption an idle screen with an interface that is gone.
             interfaceName = "",
+            // Same reasoning, and worse: a stale badge would claim the traffic
+            // of a session that no longer exists is going through a VPN.
+            isVpnBound = false,
         )
     }
 
@@ -74,6 +79,8 @@ fun SessionUiState.applyOutcome(outcome: Result<String>): SessionUiState {
         detail = sessionDetail,
         interfaceName = parsed?.optString("interface").orEmpty().takeIf { it != "null" }.orEmpty(),
         lastError = if (sessionState == "ERROR") sessionDetail else "",
+        // Absent on an older shell process, which reads correctly as unbound.
+        isVpnBound = parsed?.optBoolean("isVpnBound") == true,
     )
 }
 

--- a/app/src/main/java/dev/shizzi/TetherClient.kt
+++ b/app/src/main/java/dev/shizzi/TetherClient.kt
@@ -22,6 +22,10 @@ data class SessionUiState(
     val interfaceName: String = "",
     val lastError: String = "",
     val isVpnBound: Boolean = false,
+    /** How many devices are on the hotspot; 0 unless a session is up. */
+    val clientCount: Int = 0,
+    /** Bytes carried this session, for the notification to report. */
+    val traffic: Traffic = Traffic(),
 ) {
     /** Shizuku must be ready before the button can do anything. */
     val canStart: Boolean get() = shizukuState is ShizukuState.Ready && !isBusy
@@ -41,6 +45,11 @@ fun SessionUiState.asStopped(): SessionUiState = copy(
     detail = "Stopped",
     interfaceName = "",
     isVpnBound = false,
+    // Same reasoning: a stopped session has no clients and carries nothing,
+    // so holding the last reading would caption an idle screen with live
+    // numbers that stopped moving.
+    clientCount = 0,
+    traffic = Traffic(),
 )
 
 /**
@@ -66,6 +75,8 @@ fun SessionUiState.applyOutcome(outcome: Result<String>): SessionUiState {
             // Same reasoning, and worse: a stale badge would claim the traffic
             // of a session that no longer exists is going through a VPN.
             isVpnBound = false,
+            clientCount = 0,
+            traffic = Traffic(),
         )
     }
 
@@ -81,6 +92,11 @@ fun SessionUiState.applyOutcome(outcome: Result<String>): SessionUiState {
         lastError = if (sessionState == "ERROR") sessionDetail else "",
         // Absent on an older shell process, which reads correctly as unbound.
         isVpnBound = parsed?.optBoolean("isVpnBound") == true,
+        clientCount = parsed?.optInt("clientCount") ?: 0,
+        traffic = Traffic(
+            up = parsed?.optLong("bytesUp") ?: 0,
+            down = parsed?.optLong("bytesDown") ?: 0,
+        ),
     )
 }
 

--- a/app/src/main/java/dev/shizzi/TetherSession.kt
+++ b/app/src/main/java/dev/shizzi/TetherSession.kt
@@ -33,7 +33,8 @@ class TetherSession(private val context: Context) {
     private var detail = "not started"
     private var interfaceName: String? = null
     private var watchdog: SessionWatchdog? = null
-    private var shutdownHook: Thread? = null
+    private val teardown = SessionTeardown(context)
+    private val vpn = VpnUpstream(context) { problem -> tearDownAfter(problem) }
 
     val isActive: Boolean get() = state == SessionState.ACTIVE
 
@@ -80,6 +81,7 @@ class TetherSession(private val context: Context) {
         SessionLog.info("tun up: $name")
 
         group.startDatapath(TUN_MTU)
+        vpn.follow(group)
 
         preferTestNetworks()
         restartDownstream()
@@ -90,51 +92,32 @@ class TetherSession(private val context: Context) {
         state = SessionState.ACTIVE
         detail = "tethered clients routing through $name"
 
-        installShutdownHook()
+        teardown.installShutdownHook()
         startWatchdog(name)
         return status()
     }
 
-    /**
-     * Drops the downstream if this process exits through System.exit.
-     *
-     * Covers exactly one path: ShizukuServiceStarter calling System.exit when
-     * the server it depends on goes away. That is a real path — it is how the
-     * 13.5.4 crash took this process down — but it is the only one.
-     *
-     * ART does not unwind shutdown hooks on signal death, so SIGTERM and
-     * SIGKILL both bypass this entirely; a device test confirmed SIGTERM
-     * leaves the hotspot tethered with no hook output. Recovery for those
-     * cases lives in the app process, which outlives this one (see
-     * SessionViewModel's session-lost handling).
-     */
-    private fun installShutdownHook() {
-        val hook = Thread {
-            Log.w(TAG, "process exiting with session active; dropping downstream")
-            runCatching { DownstreamControl(context).stopWifiTethering() }
-        }
-
-        runCatching { Runtime.getRuntime().addShutdownHook(hook) }
-            .onSuccess { shutdownHook = hook }
-            .onFailure { Log.w(TAG, "installShutdownHook: ${it.message}") }
-    }
-
     /** Stops the session if the tunnel stops being the sole upstream (R6.1). */
     private fun startWatchdog(name: String) {
-        val guard = SessionWatchdog(name) { problem -> tearDownAfterDrift(problem) }
+        val guard = SessionWatchdog(name) { problem ->
+            SessionLog.warn("upstream drift: $problem")
+            tearDownAfter(problem)
+        }
         watchdog = guard
         guard.start()
     }
 
     /**
-     * Stops the session because the upstream drifted, reporting why.
+     * Stops the session because something it depends on went away.
      *
-     * A teardown failure is kept alongside the drift rather than overwritten by
+     * A teardown failure is kept alongside [problem] rather than overwritten by
      * it: "the hotspot is still up" is the more dangerous of the two, and it is
-     * the one the plain drift message would hide.
+     * the one the plain message would hide.
+     *
+     * The caller logs its own cause — upstream drift and VPN loss are different
+     * failures and each names itself before handing over.
      */
-    private fun tearDownAfterDrift(problem: String) {
-        SessionLog.warn("upstream drift: $problem")
+    private fun tearDownAfter(problem: String) {
         stop()
 
         val teardownProblem = detail.takeIf { state == SessionState.ERROR }
@@ -248,11 +231,12 @@ class TetherSession(private val context: Context) {
     fun stop(): String {
         watchdog?.stop()
         watchdog = null
-        removeShutdownHook()
+        vpn.stop()
+        teardown.removeShutdownHook()
 
-        val downstreamProblem = releaseDownstream()
+        val downstreamProblem = teardown.releaseDownstream()
 
-        releaseUpstreamSelection()
+        teardown.releaseUpstreamSelection(interfaceName)
 
         resources?.release()?.forEach { Log.w(TAG, "stop: $it") }
         resources = null
@@ -268,81 +252,13 @@ class TetherSession(private val context: Context) {
         return status()
     }
 
-    /**
-     * Hands the upstream back to the framework *before* the TUN is destroyed.
-     *
-     * This ordering is load-bearing. Destroying the interface first leaves
-     * tethering holding a reference it can no longer act on: its own teardown
-     * needs the interface to exist, so it logs
-     *
-     *     [BpfCoordinator] Could not detach program: Fail to get interface
-     *     params for interface testtunNN
-     *
-     * and keeps naming that dead interface as the current upstream. Every
-     * subsequent start then fails verifyUpstream against a ghost, permanently,
-     * with nothing the app can do about it afterward and no way for a user to
-     * clear it short of a reboot. A device test wedged a phone exactly this way
-     * for eleven consecutive sessions.
-     *
-     * So the preference is cleared while the TUN is still up, and this waits
-     * for tethering to actually move off it. The wait is bounded and best
-     * effort: if the framework has not let go by the deadline, destroying the
-     * interface is still better than leaking it, and the next start reselects
-     * from whatever remains.
-     */
-    private fun releaseUpstreamSelection() {
-        val cleared = runCatching { TetheringPreferenceApi(context).setPreferTestNetworks(false) }
-            .onFailure { Log.w(TAG, "stop: preference ${it.message}") }
-        if (cleared.isFailure) return
-
-        val name = interfaceName ?: return
-        val deadline = System.currentTimeMillis() + UPSTREAM_RELEASE_MS
-
-        while (System.currentTimeMillis() < deadline) {
-            val observed = runCatching { inspector.observe().interfaceNames }.getOrDefault(emptyList())
-            if (observed.none { it == name }) {
-                SessionLog.info("upstream released: tethering moved off $name")
-                return
-            }
-            Thread.sleep(UPSTREAM_POLL_MS)
-        }
-
-        SessionLog.warn("upstream still reads $name after ${UPSTREAM_RELEASE_MS}ms; releasing anyway")
-    }
-
-    /** @return null once no downstream is tethered, else what is still up. */
-    private fun releaseDownstream(): String? {
-        val control = DownstreamControl(context)
-
-        val didAccept = runCatching { control.stopWifiTethering() }
-            .getOrElse { failure ->
-                Log.w(TAG, "stop: downstream ${failure.message}")
-                false
-            }
-
-        val stillTethered = runCatching { DownstreamInspector().findTetheredDownstream() }
-            .getOrElse { failure -> "could not verify downstream: ${failure.message}" }
-
-        return when {
-            stillTethered != null -> stillTethered
-            didAccept -> null
-            else -> "stopTethering was rejected, but no downstream remains tethered"
-        }
-    }
-
-    private fun removeShutdownHook() {
-        shutdownHook?.let { hook ->
-            // Throws if the JVM is already shutting down, which is exactly when
-            // the hook should stay installed.
-            runCatching { Runtime.getRuntime().removeShutdownHook(hook) }
-        }
-        shutdownHook = null
-    }
-
     fun status(): String = JSONObject().apply {
         put("state", state.name)
         put("detail", detail)
         put("interface", interfaceName ?: JSONObject.NULL)
+        // A boolean rather than the handle: the handle is an opaque framework
+        // token, and nothing on the far side of the binder should render it.
+        put("isVpnBound", vpn.isBound)
     }.toString()
 
     private fun tunAddresses() = listOf(
@@ -363,16 +279,6 @@ class TetherSession(private val context: Context) {
         const val AVAILABILITY_TIMEOUT_MS = 10_000
         const val UPSTREAM_SETTLE_MS = 8_000L
         const val UPSTREAM_POLL_MS = 500L
-
-        /**
-         * How long teardown waits for tethering to release the owned TUN.
-         *
-         * Shorter than the settle deadline: this is the framework letting go of
-         * an interface rather than selecting and validating a new one, and the
-         * session is already on its way out. Exceeding it is logged and the
-         * interface destroyed regardless — leaking the TUN would be worse.
-         */
-        const val UPSTREAM_RELEASE_MS = 4_000L
 
         /**
          * How long to wait for the hotspot to come up before building the TUN.

--- a/app/src/main/java/dev/shizzi/TetherSession.kt
+++ b/app/src/main/java/dev/shizzi/TetherSession.kt
@@ -34,6 +34,7 @@ class TetherSession(private val context: Context) {
     private var interfaceName: String? = null
     private var watchdog: SessionWatchdog? = null
     private val teardown = SessionTeardown(context)
+    private val downstream = DownstreamInspector()
     private val vpn = VpnUpstream(context) { problem -> tearDownAfter(problem) }
 
     val isActive: Boolean get() = state == SessionState.ACTIVE
@@ -259,6 +260,15 @@ class TetherSession(private val context: Context) {
         // A boolean rather than the handle: the handle is an opaque framework
         // token, and nothing on the far side of the binder should render it.
         put("isVpnBound", vpn.isBound)
+
+        // Both only while active, and from deliberately different sources: the
+        // byte counters are read from /proc in process on every call, while the
+        // device count comes from dumpsys behind its own rate limit. That split
+        // is what keeps a fast poll affordable.
+        val traffic = interfaceName?.let(InterfaceCounters::read) ?: Traffic()
+        put("bytesUp", traffic.up)
+        put("bytesDown", traffic.down)
+        put("clientCount", if (isActive) downstream.countDevices() else 0)
     }.toString()
 
     private fun tunAddresses() = listOf(

--- a/app/src/main/java/dev/shizzi/Traffic.kt
+++ b/app/src/main/java/dev/shizzi/Traffic.kt
@@ -1,0 +1,45 @@
+package dev.shizzi
+
+import kotlin.math.roundToLong
+
+/**
+ * Bytes carried by a session, counted from the tethered device's point of view.
+ *
+ * "Up" is what those devices sent, "down" is what they received — the user's
+ * reading, not the phone's, since the notification showing these numbers is
+ * describing what their other devices are doing.
+ */
+data class Traffic(val up: Long = 0, val down: Long = 0) {
+
+    /**
+     * Renders a byte count the way a phone's data screen does.
+     *
+     * Decimal units rather than binary: 1.4 GB here has to agree with what
+     * Android's own data usage screen says about the same traffic, and that
+     * screen counts in powers of ten.
+     */
+    companion object {
+        private const val UNIT = 1000.0
+        private val SCALE = listOf("B", "KB", "MB", "GB", "TB")
+
+        fun format(bytes: Long): String {
+            if (bytes < UNIT) return "$bytes B"
+
+            var value = bytes.toDouble()
+            var step = 0
+            while (value >= UNIT && step < SCALE.lastIndex) {
+                value /= UNIT
+                step++
+            }
+
+            // One decimal below 10, none above: "9.4 MB" but "94 MB", which is
+            // how much precision reads as informative rather than as noise.
+            val rendered = when {
+                value < 10 -> String.format("%.1f", value)
+                else -> value.roundToLong().toString()
+            }
+            return "$rendered ${SCALE[step]}"
+        }
+    }
+}
+

--- a/app/src/main/java/dev/shizzi/UpstreamInspector.kt
+++ b/app/src/main/java/dev/shizzi/UpstreamInspector.kt
@@ -61,8 +61,17 @@ private fun interfaceExists(name: String): Boolean =
  */
 class UpstreamInspector(private val deadlineMs: Long = DEFAULT_DEADLINE_MS) {
 
-    fun observe(): UpstreamObservation {
-        val process = ProcessBuilder("dumpsys", "tethering").start()
+    fun observe(): UpstreamObservation = run("tethering")
+
+    /**
+     * The Wi-Fi dump, for facts tethering's own dump reports only historically.
+     *
+     * Same capture and timeout handling; only the service differs.
+     */
+    fun observeWifi(): UpstreamObservation = run("wifi")
+
+    private fun run(service: String): UpstreamObservation {
+        val process = ProcessBuilder("dumpsys", service).start()
         val drainPool = Executors.newFixedThreadPool(2)
 
         val stdout = drainPool.submit<String> { process.inputStream.drain() }

--- a/app/src/main/java/dev/shizzi/VpnUpstream.kt
+++ b/app/src/main/java/dev/shizzi/VpnUpstream.kt
@@ -1,0 +1,76 @@
+package dev.shizzi
+
+import android.content.Context
+
+/**
+ * Keeps the datapath pinned to a VPN for as long as the session has one.
+ *
+ * Owns the adoption rule so TetherSession is left running the lifecycle rather
+ * than also arbitrating what counts as a VPN worth binding to.
+ *
+ * Absence is not a failure: a session with no VPN runs unbound and tethers
+ * exactly as it did before this existed. Refusing to start without one would
+ * make the app useless to anyone not running a VPN, which is not what this is
+ * for. What binding buys is that once a VPN *is* adopted, losing it fails the
+ * dials instead of quietly falling back to the physical network.
+ */
+class VpnUpstream(
+    private val context: Context,
+    private val onLost: (String) -> Unit,
+) {
+
+    private var watchdog: VpnWatchdog? = null
+
+    /** 0 while unbound; the adopted VPN's handle once one is in use. */
+    var handle = UNBOUND
+        private set
+
+    val isBound: Boolean get() = handle != UNBOUND
+
+    /**
+     * Binds [group] to whatever VPN is up now, then follows it.
+     *
+     * Called before the downstream comes up so nothing can dial unbound: the
+     * datapath exists by this point, and no client can be attached yet.
+     */
+    fun follow(group: SessionResources) {
+        val watcher = VpnWatchdog(context.connectivityManager()) { binding ->
+            apply(group, binding)
+        }
+        watchdog = watcher
+
+        val adopted = watcher.adoptCurrentVpn()
+        if (adopted != UNBOUND) {
+            group.bindDatapathTo(adopted)
+            handle = adopted
+            SessionLog.info("vpn present at start: datapath pinned to handle $adopted")
+        }
+        watcher.start()
+    }
+
+    fun stop() {
+        watchdog?.stop()
+        watchdog = null
+        handle = UNBOUND
+    }
+
+    private fun apply(group: SessionResources, binding: VpnBinding) {
+        when (binding) {
+            is VpnBinding.Adopted -> {
+                group.bindDatapathTo(binding.handle)
+                handle = binding.handle
+            }
+
+            is VpnBinding.Lost -> {
+                SessionLog.warn("vpn lost: ${binding.problem}")
+                handle = UNBOUND
+                onLost(binding.problem)
+            }
+        }
+    }
+
+    private companion object {
+        /** No VPN adopted; the datapath dials over the default network. */
+        const val UNBOUND = 0L
+    }
+}

--- a/app/src/main/java/dev/shizzi/VpnWatchdog.kt
+++ b/app/src/main/java/dev/shizzi/VpnWatchdog.kt
@@ -1,0 +1,186 @@
+package dev.shizzi
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** What the poller last observed, as the session needs to act on it. */
+sealed interface VpnBinding {
+
+    /** A VPN to pin the datapath to; [handle] feeds Session.setNetwork. */
+    data class Adopted(val handle: Long) : VpnBinding
+
+    /** The adopted VPN is gone and has stayed gone. Fail closed. */
+    data class Lost(val problem: String) : VpnBinding
+}
+
+/**
+ * Follows the VPN the datapath's sockets are pinned to, and reports its loss.
+ *
+ * The datapath dials its upstream sockets from this process, so "is traffic
+ * tunnelled?" is a question about *this* process's networks rather than the
+ * app's, and the answer is only authoritative here.
+ *
+ * Polls rather than registering a callback: from the shell UID
+ * registerNetworkCallback is rejected with "Package android does not belong to
+ * 2000", while getAllNetworks and getNetworkCapabilities carry no such check.
+ * SessionResources.findNetworkOn documents the same restriction.
+ *
+ * A session that never sees a VPN runs unbound and is never torn down by this.
+ * Once one is adopted, losing it is a failure — binding is what makes that safe
+ * to promise, because an adopted session's sockets stop working the moment the
+ * VPN goes rather than falling back to the physical network. The window between
+ * the drop and this noticing therefore carries no untunnelled traffic.
+ */
+class VpnWatchdog(
+    private val connectivityManager: ConnectivityManager,
+    private val onChange: (VpnBinding) -> Unit,
+) {
+
+    private val isRunning = AtomicBoolean(false)
+    private var thread: Thread? = null
+
+    /** 0 while unbound, a handle once adopted. Touched only on the poll thread. */
+    private var boundHandle = UNBOUND
+
+    /**
+     * Consecutive polls finding no VPN at all, once one had been adopted.
+     *
+     * One miss is not evidence, for the reason SessionWatchdog debounces too: a
+     * VPN app restarting can leave a single poll empty, and a one-sample
+     * teardown would turn that into a dropped hotspot.
+     */
+    private var consecutiveMisses = 0
+
+    /**
+     * Adopts whatever VPN is up right now, so a session that starts under one
+     * is bound before any client can dial.
+     *
+     * Mutates [boundHandle] rather than only reporting it: the first poll would
+     * otherwise read the same VPN as a change and log a second adoption for a
+     * network already bound.
+     */
+    fun adoptCurrentVpn(): Long {
+        boundHandle = currentVpnHandle()
+        return boundHandle
+    }
+
+    fun start() {
+        if (!isRunning.compareAndSet(false, true)) return
+
+        thread = Thread({ monitor() }, "vpn-watchdog").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    /** Safe to call from [onChange], for the reason SessionWatchdog.stop documents. */
+    fun stop() {
+        isRunning.set(false)
+
+        val watcher = thread
+        thread = null
+        if (watcher != null && watcher != Thread.currentThread()) watcher.interrupt()
+    }
+
+    private fun monitor() {
+        while (isRunning.get()) {
+            val didSleep = runCatching { Thread.sleep(POLL_INTERVAL_MS) }.isSuccess
+            if (!didSleep || !isRunning.get()) return
+
+            val binding = evaluate() ?: continue
+            if (binding is VpnBinding.Lost) isRunning.set(false)
+
+            onChange(binding)
+            if (binding is VpnBinding.Lost) return
+        }
+    }
+
+    /**
+     * @return null while nothing needs to change, else what the session must do.
+     *
+     * The strike counter deliberately counts *absence*, never *change*. A VPN
+     * that reconnects comes back as a new Network with a new handle, and the
+     * framework offers no stable identity across that — so treating a changed
+     * handle as a loss would tear the session down on every VPN reconnect.
+     * Only a VPN still missing on the next poll is a loss.
+     */
+    private fun evaluate(): VpnBinding? {
+        val observed = currentVpnHandle()
+
+        if (observed != UNBOUND) return adopt(observed)
+
+        // Never adopted: this session makes no VPN promise, so an absent VPN is
+        // its normal state rather than a failure.
+        if (boundHandle == UNBOUND) return null
+
+        consecutiveMisses++
+        if (consecutiveMisses < MISSES_BEFORE_TEARDOWN) {
+            SessionLog.warn(
+                "vpn strike $consecutiveMisses/$MISSES_BEFORE_TEARDOWN: " +
+                    "no VPN present, session is bound to $boundHandle",
+            )
+            return null
+        }
+        return VpnBinding.Lost(VPN_LOST_DETAIL)
+    }
+
+    /** @return null when [observed] is already the bound network. */
+    private fun adopt(observed: Long): VpnBinding? {
+        consecutiveMisses = 0
+        if (observed == boundHandle) return null
+
+        val previous = boundHandle
+        boundHandle = observed
+        SessionLog.info(adoptionMessage(previous, observed))
+        return VpnBinding.Adopted(observed)
+    }
+
+    private fun currentVpnHandle(): Long = findVpn()?.let(::handleOf) ?: UNBOUND
+
+    /**
+     * The first network reporting TRANSPORT_VPN.
+     *
+     * The session's own TUN carries TRANSPORT_TEST, so it cannot be mistaken
+     * for one. Two VPNs can legitimately coexist mid-handover, and picking the
+     * first is better than refusing to pick — the handover then reads as a
+     * re-adopt on the next poll.
+     *
+     * A read that throws returns null without counting as a strike: a binder
+     * hiccup is not evidence the VPN is gone, and tearing a session down over
+     * one would be the drift response firing at nothing.
+     */
+    private fun findVpn(): Network? = runCatching {
+        connectivityManager.allNetworks.firstOrNull { candidate ->
+            connectivityManager.getNetworkCapabilities(candidate)
+                ?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
+        }
+    }.getOrElse { failure ->
+        Log.w(TAG, "findVpn: ${failure.message}")
+        null
+    }
+
+    private fun handleOf(network: Network): Long =
+        runCatching { network.networkHandle }.getOrDefault(UNBOUND)
+
+    private fun adoptionMessage(previous: Long, adopted: Long): String = when (previous) {
+        UNBOUND -> "vpn adopted: pinning the datapath to handle $adopted"
+        else -> "vpn replaced: handle $previous is gone, re-pinning to $adopted"
+    }
+
+    private companion object {
+        const val TAG = "VpnWatchdog"
+        const val UNBOUND = 0L
+        const val POLL_INTERVAL_MS = 5_000L
+
+        /** Two strikes, matching SessionWatchdog: one miss is not evidence. */
+        const val MISSES_BEFORE_TEARDOWN = 2
+
+        /** Reaches the user verbatim, through the session's detail string. */
+        const val VPN_LOST_DETAIL =
+            "The VPN disconnected, so the session was stopped to keep connected " +
+                "devices from going out unprotected."
+    }
+}

--- a/app/src/main/java/dev/shizzi/VpnWatchdog.kt
+++ b/app/src/main/java/dev/shizzi/VpnWatchdog.kt
@@ -180,7 +180,6 @@ class VpnWatchdog(
 
         /** Reaches the user verbatim, through the session's detail string. */
         const val VPN_LOST_DETAIL =
-            "The VPN disconnected, so the session was stopped to keep connected " +
-                "devices from going out unprotected."
+            "VPN disconnected. Session stopped to keep devices protected."
     }
 }

--- a/app/src/main/java/dev/shizzi/ui/HomePage.kt
+++ b/app/src/main/java/dev/shizzi/ui/HomePage.kt
@@ -65,10 +65,29 @@ fun HomePage(
 
         HomeBody(state = state, actions = actions)
 
-        StatusRow(
-            state = state,
+        // The VPN line rides with the status row rather than with the button,
+        // so both readings of "what is this session doing" sit together at the
+        // bottom edge instead of one floating mid-screen.
+        Column(
             modifier = Modifier.align(Alignment.BottomCenter),
-        )
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            // Reserved whether or not it is showing: a VPN can be adopted
+            // mid-session with the screen open, and the status row must not
+            // shift down when it is.
+            //
+            // Bottom-aligned inside the band so the line sits close to the
+            // status row it belongs with, rather than floating in the middle
+            // of its own reserved space.
+            Box(
+                modifier = Modifier.height(ShizziTheme.spacing.xxxl),
+                contentAlignment = Alignment.BottomCenter,
+            ) {
+                if (isShowingVpn(state)) VpnChip()
+            }
+
+            StatusRow(state = state)
+        }
     }
 }
 
@@ -122,6 +141,16 @@ private fun HomeHeader(
 }
 
 /**
+ * Whether the VPN line should show.
+ *
+ * Guarded on the status as well as the flag: a session torn down for VPN loss
+ * holds ERROR alongside the last VPN reading until the next publish, and the
+ * line must not outlive the session it describes.
+ */
+private fun isShowingVpn(state: SessionUiState): Boolean =
+    state.isVpnBound && state.status == UiStatus.CONNECTED
+
+/**
  * The centred stack: glyph, button, and the cancel affordance.
  *
  * Cancel appears only while starting. Stopping is already the fast path and
@@ -131,11 +160,6 @@ private fun HomeHeader(
 private fun HomeBody(state: SessionUiState, actions: HomeActions) {
     val isStarting = state.status == UiStatus.LOADING
 
-    // Guarded on the status too: a session torn down for VPN loss holds ERROR
-    // alongside the last VPN reading until the next publish, and the badge must
-    // not outlive the session it describes.
-    val isShowingVpn = state.isVpnBound && state.status == UiStatus.CONNECTED
-
     Column(
         modifier = Modifier.fillMaxSize().padding(ScreenPadding),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -143,18 +167,10 @@ private fun HomeBody(state: SessionUiState, actions: HomeActions) {
     ) {
         StatusIcon(status = state.status)
 
-        Spacer(Modifier.height(ShizziTheme.spacing.xl))
-
-        // Reserved whether or not it is showing, for the same reason the cancel
-        // affordance below is: a VPN can be adopted mid-session with the screen
-        // open, and the button must not jump when it is. Sized to clear the
-        // brutalist shadow, which is drawn outside the chip's own bounds.
-        Box(
-            modifier = Modifier.height(ShizziTheme.spacing.xxxl),
-            contentAlignment = Alignment.Center,
-        ) {
-            if (isShowingVpn) VpnChip()
-        }
+        // Two of the largest step rather than one arbitrary value, so the
+        // gap stays on the spacing scale. It preserves the distance from when
+        // a reserved VPN band sat between the glyph and the button.
+        Spacer(Modifier.height(ShizziTheme.spacing.xxxl * 2))
 
         ConnectButton(
             label = buttonLabel(state.status),

--- a/app/src/main/java/dev/shizzi/ui/HomePage.kt
+++ b/app/src/main/java/dev/shizzi/ui/HomePage.kt
@@ -131,6 +131,11 @@ private fun HomeHeader(
 private fun HomeBody(state: SessionUiState, actions: HomeActions) {
     val isStarting = state.status == UiStatus.LOADING
 
+    // Guarded on the status too: a session torn down for VPN loss holds ERROR
+    // alongside the last VPN reading until the next publish, and the badge must
+    // not outlive the session it describes.
+    val isShowingVpn = state.isVpnBound && state.status == UiStatus.CONNECTED
+
     Column(
         modifier = Modifier.fillMaxSize().padding(ScreenPadding),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -138,7 +143,18 @@ private fun HomeBody(state: SessionUiState, actions: HomeActions) {
     ) {
         StatusIcon(status = state.status)
 
-        Spacer(Modifier.height(ShizziTheme.spacing.xxxl))
+        Spacer(Modifier.height(ShizziTheme.spacing.xl))
+
+        // Reserved whether or not it is showing, for the same reason the cancel
+        // affordance below is: a VPN can be adopted mid-session with the screen
+        // open, and the button must not jump when it is. Sized to clear the
+        // brutalist shadow, which is drawn outside the chip's own bounds.
+        Box(
+            modifier = Modifier.height(ShizziTheme.spacing.xxxl),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (isShowingVpn) VpnChip()
+        }
 
         ConnectButton(
             label = buttonLabel(state.status),

--- a/app/src/main/java/dev/shizzi/ui/VpnChip.kt
+++ b/app/src/main/java/dev/shizzi/ui/VpnChip.kt
@@ -1,0 +1,42 @@
+package dev.shizzi.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import dev.shizzi.ui.theme.ShizziTheme
+import dev.shizzi.ui.theme.brutalSurface
+
+/**
+ * Says the tunnel is carrying traffic out through a VPN.
+ *
+ * Neutral rather than turquoise: the palette reserves the accent for a state
+ * worth acting on, and a VPN being up is merely true. The connected status
+ * glyph above is already the one saturated thing on screen, and a second would
+ * give the eye two things claiming to be the most important.
+ *
+ * "VIA VPN" rather than "PROTECTED", which overclaims — the app cannot vouch
+ * for what the VPN does — and rather than "VPN ACTIVE", which reads equally as
+ * "your VPN is on", a thing the system status bar already says. What this adds
+ * is that the *tethered clients* are going out through it.
+ */
+@Composable
+fun VpnChip() {
+    Row(
+        modifier = Modifier
+            .brutalSurface(fill = ShizziTheme.colors.surface)
+            .padding(
+                horizontal = ShizziTheme.spacing.md,
+                vertical = ShizziTheme.spacing.sm,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "VIA VPN",
+            style = ShizziTheme.typography.caption,
+            color = ShizziTheme.colors.onSurfaceMuted,
+        )
+    }
+}

--- a/app/src/main/java/dev/shizzi/ui/VpnChip.kt
+++ b/app/src/main/java/dev/shizzi/ui/VpnChip.kt
@@ -1,42 +1,49 @@
 package dev.shizzi.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.VpnKey
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import dev.shizzi.ui.theme.ShizziTheme
-import dev.shizzi.ui.theme.brutalSurface
 
 /**
- * Says the tunnel is carrying traffic out through a VPN.
+ * Says the tethered clients are going out through a VPN.
  *
- * Neutral rather than turquoise: the palette reserves the accent for a state
- * worth acting on, and a VPN being up is merely true. The connected status
- * glyph above is already the one saturated thing on screen, and a second would
- * give the eye two things claiming to be the most important.
+ * No surface behind it. Every bordered element in this app is something to
+ * press, so wearing that treatment made a label look like a control; without
+ * it, nothing about this invites a tap.
  *
- * "VIA VPN" rather than "PROTECTED", which overclaims — the app cannot vouch
- * for what the VPN does — and rather than "VPN ACTIVE", which reads equally as
- * "your VPN is on", a thing the system status bar already says. What this adds
- * is that the *tethered clients* are going out through it.
+ * The key glyph is the one Android itself puts in the status bar for an active
+ * VPN, so it is already the thing a user reads as "VPN" without being taught.
+ *
+ * Drawn in the accent. The palette otherwise reserves it for a state worth
+ * acting on, and a VPN being up is merely true — but this is the one thing on
+ * the screen a user opens the app to confirm, and with no surface to frame it
+ * the colour is what keeps it from reading as a caption.
  */
 @Composable
 fun VpnChip() {
     Row(
-        modifier = Modifier
-            .brutalSurface(fill = ShizziTheme.colors.surface)
-            .padding(
-                horizontal = ShizziTheme.spacing.md,
-                vertical = ShizziTheme.spacing.sm,
-            ),
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(ShizziTheme.spacing.sm),
     ) {
+        Icon(
+            imageVector = Icons.Filled.VpnKey,
+            contentDescription = null,
+            tint = ShizziTheme.colors.primary,
+            modifier = Modifier.size(ShizziTheme.spacing.lg),
+        )
+
         Text(
-            text = "VIA VPN",
+            text = "VPN CONNECTED",
             style = ShizziTheme.typography.caption,
-            color = ShizziTheme.colors.onSurfaceMuted,
+            color = ShizziTheme.colors.primary,
         )
     }
 }

--- a/datapath/bind.go
+++ b/datapath/bind.go
@@ -1,0 +1,19 @@
+package datapath
+
+/*
+#cgo LDFLAGS: -landroid
+#include <android/multinetwork.h>
+*/
+import "C"
+
+import "fmt"
+
+// bindToNetwork pins fd to the network identified by handle.
+func bindToNetwork(handle uint64, fd uintptr) error {
+	rc, errno := C.android_setsocknetwork(C.net_handle_t(handle), C.int(fd))
+	if rc != 0 {
+		return fmt.Errorf("bindToNetwork: android_setsocknetwork(handle=%d, fd=%d): %w",
+			handle, fd, errno)
+	}
+	return nil
+}

--- a/datapath/datapath.go
+++ b/datapath/datapath.go
@@ -30,7 +30,8 @@ const nicID tcpip.NICID = 1
 // this deliberately exposes no gVisor types: the Kotlin side sees a handle it
 // can start and stop, nothing more.
 type Session struct {
-	stack *stack.Stack
+	stack   *stack.Stack
+	binding *networkBinding
 }
 
 // Start builds a netstack over tunFD and attaches it to the TUN.
@@ -81,9 +82,33 @@ func Start(tunFD int, mtu int) (*Session, error) {
 		{Destination: header.IPv6EmptySubnet, NIC: nicID},
 	})
 
-	installForwarders(netStack, &net.Dialer{Timeout: dialTimeout})
+	binding := &networkBinding{}
+	installForwarders(netStack, &net.Dialer{
+		Timeout: dialTimeout,
+		Control: binding.control,
+	})
 
-	return &Session{stack: netStack}, nil
+	return &Session{stack: netStack, binding: binding}, nil
+}
+
+// SetNetwork pins every subsequent dial to the given network handle.
+//
+// 0 unbinds, which is how a session with no VPN behaves: dials follow the shell
+// process's default network. Callers pass a value from Network.getNetworkHandle.
+//
+// Binding is what makes VPN loss fail rather than fall back. An unbound socket
+// follows the default network, so the moment a VPN drops it leaves over the
+// physical one instead and tethered clients keep browsing untunneled with
+// nothing in the stack noticing.
+//
+// int64 rather than uint64 because gomobile has no unsigned type. A handle
+// packs a netid above a fixed magic word, so it is routinely negative as a
+// signed value; the conversion reinterprets the bits without changing them.
+func (s *Session) SetNetwork(handle int64) {
+	if s.binding == nil {
+		return
+	}
+	s.binding.set(uint64(handle))
 }
 
 // Stop tears the netstack down. It does not close the TUN fd.

--- a/datapath/network.go
+++ b/datapath/network.go
@@ -1,0 +1,48 @@
+package datapath
+
+import (
+	"sync/atomic"
+	"syscall"
+)
+
+// unbound is NETWORK_UNSPECIFIED: dial over whatever the process default is.
+//
+// Not a failure case. A session with no VPN runs here permanently and tethers
+// exactly as it did before any of this existed.
+const unbound = 0
+
+// networkBinding is the network every new dial is pinned to, swapped live.
+//
+// Atomic because the writer and the readers are different threads: the VPN
+// watchdog calls SetNetwork from its own thread while forwarder goroutines are
+// dialling.
+type networkBinding struct {
+	handle atomic.Uint64
+}
+
+// control pins each new socket before it connects.
+//
+// Dialer.Control runs after the socket exists and before connect(2), which is
+// the only window where this takes effect — binding afterwards does nothing to
+// a socket that has already chosen its route.
+//
+// An error here fails the dial, which is the point: a socket that could not be
+// pinned to the VPN must not quietly leave over the physical network instead.
+func (b *networkBinding) control(network, address string, conn syscall.RawConn) error {
+	handle := b.handle.Load()
+	if handle == unbound {
+		return nil
+	}
+
+	var bindErr error
+	if err := conn.Control(func(fd uintptr) {
+		bindErr = bindToNetwork(handle, fd)
+	}); err != nil {
+		return err
+	}
+	return bindErr
+}
+
+func (b *networkBinding) set(handle uint64) {
+	b.handle.Store(handle)
+}


### PR DESCRIPTION
Surfaces whether a tethering session is going out through a VPN, and stops the session when that VPN drops instead of letting connected devices silently fall back to the carrier. Closes #6.

- Pinned every socket the datapath dials to a chosen network, so losing the VPN fails the connection rather than quietly re-routing it over the physical network
- Added a watchdog in the privileged process that follows the VPN a session is bound to, since that is the only process where the answer is authoritative
- Adopted a VPN that appears after a session has already started, and re-pinned to a new one when a VPN reconnects, which arrives as a different network than the one that went away
- Tore the session down when the VPN has been gone for two consecutive checks, debounced so a brief reconnect does not drop the hotspot
- Left sessions that never see a VPN running exactly as before, unbound and untouched
- Added a VPN indicator to the home screen, shown only while a session is actually connected and bound
- Rewrote the notification wording, dropping a claim of protection that read identically whether or not a VPN was up
- Moved the VPN fact into the notification title, where it is visible without expanding
- Replaced the notification body with the number of connected devices and how much has been carried in each direction
- Stopped raw exception text and internal interface names from reaching the notification, leaving them in the log where they are useful
- Read byte counts from the kernel rather than from the userspace stack, which cannot see traffic the kernel forwards on its own and was under-reporting by orders of magnitude
- Read the device count from the wireless layer rather than from the tethering tables, which keep naming devices for minutes after they disconnect
- Rate-limited the expensive part of a status read so the visible numbers can refresh every second without spending a subprocess each time
- Fixed the notification staying stuck on stale text for the duration of a teardown

Verified on a Pixel 10a with a real VPN and a tethered client. Dropping the VPN mid-session broke the client's connection immediately, which is what proves the socket pinning is doing the work rather than the polling. Connecting a VPN mid-session was picked up and applied without interrupting the session. Device count and throughput were checked against the phone's own accounting, and the count returns to zero after a client disconnects. Byte counters were confirmed to track a known transfer. Sessions with no VPN were confirmed unchanged.
