### PR TITLE
fix: build the datapath off Android so its tests can run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,10 +58,16 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Test datapath
+        # Runs on the host, not under the NDK: an android/arm64 test binary
+        # would not execute on this runner. bind.go is tagged android-only and
+        # stubbed elsewhere precisely so the package builds here.
+        run: cd datapath && go test ./...
+
       - name: Vet datapath
-        # The datapath is cgo against <android/multinetwork.h>, so it only
-        # compiles for Android. Vetting it under the NDK toolchain catches
-        # breakage here rather than inside the gomobile bind further down.
+        # Also vet the real Android build. The stub means a host-only check
+        # would never look at bind.go, which is the one file that can break on
+        # a toolchain the tests do not use.
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_SDK_ROOT }}/ndk/27.0.12077973
         run: |

--- a/datapath/bind.go
+++ b/datapath/bind.go
@@ -1,3 +1,5 @@
+//go:build android
+
 package datapath
 
 /*

--- a/datapath/bind_stub.go
+++ b/datapath/bind_stub.go
@@ -1,0 +1,20 @@
+//go:build !android
+
+package datapath
+
+import "errors"
+
+// bindToNetwork is Android-only: android_setsocknetwork comes from libandroid
+// and has no equivalent anywhere else, so the real implementation in bind.go
+// cannot compile off Android. This stub takes its place there, which is what
+// lets the package -- and so its tests -- build on a CI runner.
+//
+// Returning an error rather than nil is deliberate. Nothing reaches this in a
+// real session: control returns early while the binding is unbound, and a
+// handle only ever comes from the Android side. If that stops being true, a
+// dial that believes it is pinned to a VPN fails here instead of silently
+// leaving over the physical network -- the same fail-closed answer the real
+// implementation gives when the bind itself fails.
+func bindToNetwork(handle uint64, fd uintptr) error {
+	return errors.New("bindToNetwork: not supported on this platform")
+}


### PR DESCRIPTION
`datapath_test.go` has never run anywhere — not locally, not in CI.

## Why

`bind.go` is cgo against `<android/multinetwork.h>` and carried no build constraint, so Go compiled it for every target. Off Android there is no such header:

```
./bind.go:5:10: fatal error: android/multinetwork.h: No such file or directory
FAIL  dev.shizzi/datapath [build failed]
```

**Build failed, not test failed** — nothing ever ran. And the test does not touch this code: it exercises the gvisor stack over a channel endpoint. But a Go package is a compilation unit, so one unbuildable file took its neighbours down with it.

## The change

- `bind.go` gets `//go:build android`.
- New `bind_stub.go` (`//go:build !android`) supplies the same signature everywhere else.

The stub returns an error rather than `nil`. Nothing reaches it in a real session — `control` returns early while unbound, and a handle only ever comes from the Android side — but if that stops holding, a dial that believes it is pinned to a VPN should fail rather than quietly leave over the physical network. Same fail-closed answer the real implementation gives when the bind itself fails.

## CI

Adds `go test ./datapath` on the host, and **keeps** the Android vet. The second one looks redundant and is not: with the stub in place, a host-only check never compiles `bind.go` at all, so the single file most likely to break on the NDK toolchain would go completely unexamined.

I verified that by breaking `bind.go` on purpose:

| Check | Broken `bind.go` |
| --- | --- |
| Host `go test` | `ok` — blind to it |
| Android `go vet` | `could not determine what C.android_setsocknetwork_TYPO refers to` |

## Verified

- **Linux (`golang:1.26.3`, matching the CI pin):** `ok dev.shizzi/datapath` — `TestStackRoutesBothFamilies` passes, IPv4 and IPv6 subtests. Before the change, same command: `FAIL [build failed]`.
- **Android untouched:** `go build` and `go vet` clean for `android/arm64` under NDK 27.0.12077973, and a full `./gradlew assembleDebug` succeeds — which compiles the datapath through `gomobile bind`, so the shipping path is confirmed end to end.
- `gofmt` clean.

Those two passing subtests are the IPv6 routing shipped in v0.2.0 — the fix for the VPN leak. Nothing verified it on every commit until now.

## Known limitation

This does **not** make `go test ./datapath` work on macOS. `datapath.go` imports gvisor's `fdbased`/`rawfile`, which is Linux-only — a separate constraint this PR does not address. The tests run in CI, which is where they were always meant to.