### PR TITLE
fix: make a session start on more devices, and say why when it does not

### DIFF
--- a/app/src/main/java/dev/shizzi/SessionService.kt
+++ b/app/src/main/java/dev/shizzi/SessionService.kt
@@ -124,6 +124,18 @@ class SessionService : Service() {
             }
             if (attempt != generation) return@launch
 
+            // The shell process logs its own start failures. This covers the
+            // ones it never hears about -- a bind that never completed, a
+            // contract check that rejected the daemon -- which otherwise
+            // appeared on screen and nowhere else, leaving the log a user sends
+            // in with no record of the failure they are reporting.
+            outcome.exceptionOrNull()?.let { failure ->
+                SessionLog.error(
+                    "start failed in the app process: " +
+                        "${failure.javaClass.name}: ${failure.message}",
+                )
+            }
+
             internalState.update { current -> current.applyOutcome(outcome) }
             publishState()
             followStatus()

--- a/app/src/main/java/dev/shizzi/SessionViewModel.kt
+++ b/app/src/main/java/dev/shizzi/SessionViewModel.kt
@@ -136,6 +136,13 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
                         DiagnosticsState.Complete(report, TetherService.REPORT_PATH)
                     },
                     onFailure = { failure ->
+                        // Same reason as the service's start path: a run that
+                        // never reached the shell process publishes no report,
+                        // so without this the failure is on screen only.
+                        SessionLog.error(
+                            "diagnostics failed in the app process: " +
+                                "${failure.javaClass.name}: ${failure.message}",
+                        )
                         DiagnosticsState.Failed(
                             "${failure.javaClass.simpleName}: ${failure.message}",
                         )

--- a/app/src/main/java/dev/shizzi/TetherClient.kt
+++ b/app/src/main/java/dev/shizzi/TetherClient.kt
@@ -133,7 +133,12 @@ class TetherClient {
         // the interface alive in the kernel.
         .tag(SERVICE_TAG)
         .processNameSuffix("probe")
-        .debuggable(true)
+        // Shizuku turns this into "-Xcompiler-option --debuggable
+        // -XjdwpProvider:adbconnection" on the app_process command line, which
+        // costs the shell process its AOT code for the whole of its life. Worth
+        // it to attach a debugger to it; not worth it on a user's phone, where
+        // it only makes a start that is already the slowest part slower.
+        .debuggable(BuildConfig.DEBUG)
         .version(TetherService.CONTRACT_VERSION)
 
     private val connection = object : ServiceConnection {

--- a/app/src/main/java/dev/shizzi/TetherClient.kt
+++ b/app/src/main/java/dev/shizzi/TetherClient.kt
@@ -5,6 +5,7 @@ import android.content.ServiceConnection
 import android.os.IBinder
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.json.JSONObject
@@ -175,10 +176,36 @@ class TetherClient {
         pendingBind = deferred
         Shizuku.bindUserService(userServiceArgs, connection)
 
-        val bound = withTimeout(BIND_TIMEOUT_MS) { deferred.await() }
+        val bound = awaitBind(deferred)
         observeDeath(bound)
         return bound
     }
+
+    /**
+     * Restates a timeout as what actually went wrong.
+     *
+     * R8 renames TimeoutCancellationException, so the class name the UI shows
+     * is a letter and a digit and the message is kotlinx's, which knows nothing
+     * about what was being awaited. Every distinct way the shell process can
+     * fail to appear -- never started, started and exited, still starting --
+     * reached the user as the same uninformative string.
+     *
+     * IllegalStateException survives minification with its name intact, being
+     * a platform class.
+     */
+    private suspend fun awaitBind(deferred: CompletableDeferred<ITetherService>): ITetherService =
+        try {
+            withTimeout(BIND_TIMEOUT_MS) { deferred.await() }
+        } catch (timeout: TimeoutCancellationException) {
+            pendingBind = null
+            throw IllegalStateException(
+                "bindUserService: Shizuku returned no binder for the privileged " +
+                    "helper within ${BIND_TIMEOUT_MS}ms. The shell process either " +
+                    "never started or exited before handing one back; " +
+                    "`adb logcat -s ShizukuServiceStarter:*` carries the reason.",
+                timeout,
+            )
+        }
 
     /**
      * onServiceDisconnected does not cover this: the shell process is a child

--- a/app/src/main/java/dev/shizzi/TetherClient.kt
+++ b/app/src/main/java/dev/shizzi/TetherClient.kt
@@ -331,10 +331,16 @@ class TetherClient {
         private const val SERVICE_TAG = "shizzi-session"
 
         /**
-         * Covers only the bind, which is fast. The probe run is not: Q5 waits
+         * Deliberately longer than the 30s Shizuku gives a user service to
+         * start (UserServiceRecord.setStartingTimeout), so the server's own
+         * deadline is the one that decides. At 10s this expired while the shell
+         * process was still legitimately starting, and reported a failure for a
+         * bind that had not failed.
+         *
+         * Covers only the bind. The probe run is not bounded by this: Q5 waits
          * up to 45s for upstream selection to settle.
          */
-        const val BIND_TIMEOUT_MS = 10_000L
+        const val BIND_TIMEOUT_MS = 35_000L
 
         /** R3.3 suggests a 10s bound on test-network availability. */
         const val AVAILABILITY_TIMEOUT_MS = 10_000

--- a/app/src/main/java/dev/shizzi/TetherService.kt
+++ b/app/src/main/java/dev/shizzi/TetherService.kt
@@ -11,21 +11,31 @@ import android.util.Log
  */
 class TetherService : ITetherService.Stub {
 
-    private val runner: ProbeRunner
-    private val session: TetherSession
+    private val context: Context
+
+    /**
+     * Resolved on first call rather than in the constructor.
+     *
+     * Shizuku's UserService.create catches whatever a constructor throws,
+     * returns null, and ServiceStarter exits: no binder is ever sent, and the
+     * app waits out its bind timeout with nothing to report but the timeout.
+     * Rebasing is the step here most likely to fail on a build that has moved
+     * its internals, so it has to fail where a caller can hear about it.
+     */
+    private val shellContext: Context by lazy { asShellContext(context) }
+    private val runner: ProbeRunner by lazy { ProbeRunner(shellContext) }
+    private val session: TetherSession by lazy { TetherSession(shellContext) }
 
     @Suppress("unused")
     constructor() : this(acquireSystemContext())
 
     /**
      * Shizuku prefers this constructor and supplies a context packaged as
-     * "android", so the rebasing has to happen here and not only in the no-arg
-     * path, which is the one that never runs.
+     * "android", so the rebasing has to be reachable from here and not only
+     * from the no-arg path, which is the one that never runs.
      */
     constructor(context: Context) {
-        val shellContext = asShellContext(context)
-        runner = ProbeRunner(shellContext)
-        session = TetherSession(shellContext)
+        this.context = context
         liveInstance = this
     }
 
@@ -34,7 +44,7 @@ class TetherService : ITetherService.Stub {
     override fun start(logging: Boolean): String {
         SessionLog.setEnabled(logging)
         return runCatching { session.start() }
-            .getOrElse { failure -> errorReport("start", failure) }
+            .getOrElse { failure -> sessionError("start", failure) }
     }
 
     /**
@@ -46,12 +56,12 @@ class TetherService : ITetherService.Stub {
             .onFailure { failure -> Log.w(TAG, "stop: probe teardown ${failure.message}") }
 
         return runCatching { session.stop() }
-            .getOrElse { failure -> errorReport("stop", failure) }
+            .getOrElse { failure -> sessionError("stop", failure) }
     }
 
     override fun getStatus(): String =
         runCatching { session.status() }
-            .getOrElse { failure -> errorReport("getStatus", failure) }
+            .getOrElse { failure -> sessionError("getStatus", failure) }
 
     /** Pushed by the app, which writes few entries and holds the only DataStore. */
     override fun setLogging(enabled: Boolean) {
@@ -93,6 +103,21 @@ class TetherService : ITetherService.Stub {
 
         Log.i(TAG, "report: $report")
         return report
+    }
+
+    /**
+     * A failure in the shape the app folds into its screen.
+     *
+     * Not [errorReport], which is a probe report: applyOutcome reads "state"
+     * and a report carries none, so a start failing this way would render as an
+     * idle screen rather than an error. Only [runProbes] is read as a report.
+     */
+    private fun sessionError(operation: String, failure: Throwable): String {
+        Log.e(TAG, "$operation failed", failure)
+        return org.json.JSONObject().apply {
+            put("state", SessionState.ERROR.name)
+            put("detail", "$operation: ${failure.javaClass.simpleName}: ${failure.message}")
+        }.toString()
     }
 
     private fun errorReport(operation: String, failure: Throwable): String {


### PR DESCRIPTION
Closes #14.

Every way the privileged shell process can fail to appear reached the user as one string: `q0: Timed out waiting for 10000 ms`. Two of the causes were ours; the rest were unattributable.

## Changes

**`.debuggable(BuildConfig.DEBUG)`** — was unconditional. Shizuku renders it as `-Xcompiler-option --debuggable -XjdwpProvider:adbconnection` on the `app_process` command line, so every user's shell process ran without AOT code. The flag exists to attach a debugger during development.

**`BIND_TIMEOUT_MS` 10s → 35s** — Shizuku allows a user service 30s to start (`UserServiceRecord.setStartingTimeout`). At 10s the client declared failure while the server was still starting the process, and a stop between attempts destroys the record, so the next attempt started cold and failed the same way.

**Attributed bind failure** — `withTimeout` throws `TimeoutCancellationException`, which R8 renames, and kotlinx's message names no operation. It is now restated as an `IllegalStateException` (a platform class, so its name survives minification) naming what was awaited and where the reason is. Bind failures are also written to `SessionLog`, which recorded none of them before, from both the session and diagnostics paths.

**Context rebasing deferred out of the `TetherService` constructor** — Shizuku's `UserService.create` answers a throwing constructor by returning null, and `ServiceStarter` exits the process. `asShellContext` / `forceOpPackageName` therefore took the shell process down before it could report anything. Both now resolve on first call, so the failure returns over the binder.

`start`, `stop` and `getStatus` return a session-shaped error to match. They previously returned a probe report, which carries no `state` key — `applyOutcome` would have read a failed start as an idle screen.

## Testing

Not reproduced on hardware; the reporting device is a RuggedOne Xever 7 on Android 15. The two candidate causes are distinguished by `adb logcat -s ShizukuServiceStarter:*`, and the changes here address both. No behaviour change on a device where the bind already succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)