### PR TITLE
chore: remove all comments

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,29 +3,10 @@ import java.util.Properties
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    // Required from Kotlin 2.0 onward whenever buildFeatures.compose is enabled.
+
     id("org.jetbrains.kotlin.plugin.compose")
 }
 
-/**
- * Builds the Go datapath into an AAR.
- *
- * The AAR is a build product, not a checked-in binary: leaving a stale one in
- * the tree is how the shell process ends up running a datapath that does not
- * match the source next to it.
- *
- * gomobile is not on Gradle's PATH under Android Studio, so the toolchain is
- * located explicitly and the task fails loudly when it is missing rather than
- * silently producing an APK with no datapath in it.
- */
-/**
- * A stable fingerprint of the shell-side sources.
- *
- * The daemon survives APK replacement and will not reload a class it has
- * already loaded, so the app needs a value that changes when the code does —
- * and only then. A timestamp would change on every configuration and defeat
- * Gradle's up-to-date checks; hashing the sources does not.
- */
 fun sourceFingerprint(projectDir: File): Int {
     val sources = File(projectDir, "src/main/java")
     if (!sources.isDirectory) return 0
@@ -76,35 +57,19 @@ android {
 
     defaultConfig {
         applicationId = "dev.shizzi"
-        // TetheringManager.setPreferTestNetworks, the one call the whole
-        // approach rests on, was added in API 33. Below it the app installs,
-        // launches, and can do nothing but report UNSUPPORTED. Rejecting those
-        // devices at install time is the honest failure.
+
         minSdk = 33
         targetSdk = 35
         versionCode = 2
         versionName = "0.2.0"
 
-        // Identifies the build to the shell-side daemon, which survives APK
-        // replacement and will not reload an already-loaded class. Without a
-        // per-build value a rebuilt implementation keeps running old code
-        // behind an unchanged AIDL surface, silently. Derived from the source
-        // rather than the clock so it is stable across rebuilds of unchanged
-        // code and does not defeat Gradle's up-to-date checks.
         buildConfigField("int", "SERVICE_BUILD_ID", "${sourceFingerprint(projectDir)}")
 
-        // The datapath AAR ships arm64 only. Filtering here keeps the APK from
-        // claiming ABIs whose libgojni.so it does not contain, which would fail
-        // at load time on a 32-bit device rather than at install.
         ndk {
             abiFilters += "arm64-v8a"
         }
     }
 
-    // Loaded from a gitignored file locally and written by CI from secrets.
-    // Absent on a fresh clone, which is why every read below is guarded: an
-    // unsigned debug build must still work for someone who has never seen the
-    // key.
     val keystoreProperties = Properties().apply {
         val file = rootProject.file("keystore.properties")
         if (file.exists()) file.inputStream().use { load(it) }
@@ -134,10 +99,6 @@ android {
                 "proguard-rules.pro",
             )
 
-            // Only when the key is actually present. Configuring it
-            // unconditionally makes every release build fail on a machine
-            // without the keystore, including CI runs that only need to check
-            // that the project compiles.
             if (keystoreProperties.getProperty("storeFile") != null) {
                 signingConfig = signingConfigs.getByName("release")
             }
@@ -164,20 +125,16 @@ android {
     }
 }
 
-// The Go datapath must exist before Kotlin compiles against it.
 tasks.named("preBuild") { dependsOn(gomobileBind) }
 
 dependencies {
-    // The gomobile AAR, built from /datapath by the task above.
+
     implementation(files(layout.buildDirectory.file("gomobile/datapath.aar")))
 
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.activity:activity-compose:1.9.3")
 
-    // Settings that survive a restart. The theme choice has to be readable
-    // before the first frame, so this is read synchronously once at startup
-    // and observed as a flow thereafter.
     implementation("androidx.datastore:datastore-preferences:1.1.1")
 
     val composeBom = platform("androidx.compose:compose-bom:2025.08.00")
@@ -185,19 +142,12 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.material3:material3")
 
-    // The app draws seven-plus glyphs across three screens. Hand-drawing them
-    // on Canvas, as the first build did for its single gear, produces icons that
-    // drift in stroke weight and optical size against each other. R8 shrinks
-    // the unused catalogue out of the release build.
     implementation("androidx.compose.material:material-icons-extended")
     implementation("androidx.compose.ui:ui-tooling-preview")
     debugImplementation("androidx.compose.ui:ui-tooling")
 
-    // Shizuku: API surface + the provider that publishes the binder to us.
     implementation("dev.rikka.shizuku:api:13.1.5")
     implementation("dev.rikka.shizuku:provider:13.1.5")
 
-    // Required to call hidden framework APIs on API 28+ without hitting the
-    // greylist/blocklist enforcement. See docs/hidden-api-record.md.
     implementation("org.lsposed.hiddenapibypass:hiddenapibypass:4.3")
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,59 +1,20 @@
-# R8 rules for the release build.
-#
-# Everything here exists because something outside this APK reaches into it by
-# name. R8 reasons about the call graph it can see; a class only ever
-# instantiated by the framework, by Shizuku, or across a binder looks unused to
-# it, and the failure lands at runtime rather than at build time.
-
-# --- Shizuku's user service ------------------------------------------------
-#
-# TetherService runs in a separate, shell-uid process that Shizuku starts. It
-# is named as a string in UserServiceArgs and instantiated reflectively, via
-# either the no-arg or the Context constructor. Renaming the class breaks the
-# lookup; stripping a constructor breaks instantiation with a NoSuchMethod that
-# reads like Shizuku itself is broken.
 -keep class dev.shizzi.TetherService { *; }
 
-# --- The AIDL contract -----------------------------------------------------
-#
-# Both sides of the binder must agree on names. The Stub/Proxy machinery is
-# generated and dispatches on method identity, so it cannot be renamed on one
-# side only — and the two sides here are two different processes.
 -keep interface dev.shizzi.ITetherService { *; }
 -keep class dev.shizzi.ITetherService$* { *; }
 
-# --- Shizuku itself --------------------------------------------------------
-#
-# The library's own binder surface, called from the shell process.
 -keep class rikka.shizuku.** { *; }
 -dontwarn rikka.shizuku.**
 
-# --- Hidden framework APIs -------------------------------------------------
-#
-# HiddenApi.kt reflects onto android.net.* internals. Those classes live in the
-# framework, not this APK, so R8 does not rename them and no keep rule applies
-# to them. What does matter is that the reflection is driven by string literals
-# R8 must not fold away, and HiddenApiBypass reflects onto its own targets.
 -keep class org.lsposed.hiddenapibypass.** { *; }
 -dontwarn org.lsposed.hiddenapibypass.**
 
-# The framework instantiates these by name from the manifest.
 -keep class dev.shizzi.App
 -keep class dev.shizzi.MainActivity
 -keep class dev.shizzi.SessionService
 
-# --- Kotlin metadata -------------------------------------------------------
-#
-# Kept so reflective constructor lookup on TetherService resolves parameter
-# types as declared rather than as R8's rewritten signatures.
 -keepattributes RuntimeVisibleAnnotations,RuntimeVisibleParameterAnnotations
 -keepattributes Signature,InnerClasses,EnclosingMethod
 
-# --- Diagnostics -----------------------------------------------------------
-#
-# Line numbers survive into release stack traces, which the probe report and
-# the log screen surface verbatim. Without these a user-reported failure names
-# an obfuscated frame and says nothing. The source file name is renamed rather
-# than kept, since it adds nothing once line numbers are present.
 -keepattributes SourceFile,LineNumberTable
 -renamesourcefileattribute SourceFile

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,27 +2,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- R1.1: required to talk to Shizuku at all. -->
     <uses-permission android:name="moe.shizuku.manager.permission.API" />
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <!--
-      The session outlives the UI. Without a foreground service this process is
-      cached the moment the user leaves, and whatever kills it takes the death
-      recipient with it — leaving the hotspot tethered and clients silently
-      routed over cellular, which is the failure the session exists to prevent.
-    -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <!--
-      Held by the shell UID at runtime, not by this app. Declared so the
-      manifest records the privileged surface the UserService relies on; the
-      app process is never granted these.
-    -->
     <uses-permission
         android:name="android.permission.MANAGE_TEST_NETWORKS"
         tools:ignore="ProtectedPermissions" />
@@ -48,14 +36,6 @@
             </intent-filter>
         </activity>
 
-        <!--
-          Owns the session for as long as it is up, so the shell process's
-          death recipient stays registered even with no UI on screen.
-
-          specialUse because no standard type describes this honestly: it is
-          not dataSync, connectedDevice, or location. The subtype below records
-          what the service actually does.
-        -->
         <service
             android:name=".SessionService"
             android:exported="false"
@@ -66,22 +46,6 @@
                     down the hotspot if the privileged helper process dies" />
         </service>
 
-        <!--
-          R1.1: the provider is how the Shizuku server reaches into this app to
-          deliver the binder, so it must be exported — ShizukuProvider asserts
-          this at attach time and throws otherwise.
-
-          R2.3's "not exported" applies to the UserService, not here. Access is
-          gated instead by INTERACT_ACROSS_USERS_FULL, a signature-level
-          permission no ordinary app can hold.
-        -->
-        <!--
-          Serves the exported probe report to whichever app the user picks.
-
-          Not exported, and granted per intent: the receiving app gets a
-          read permission scoped to the one uri, for as long as the intent
-          lives, rather than standing access to app storage.
-        -->
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.exports"

--- a/app/src/main/java/dev/shizzi/App.kt
+++ b/app/src/main/java/dev/shizzi/App.kt
@@ -8,38 +8,20 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 
-/**
- * Holds the app Context for [ShizukuGate] and lifts hidden-API restrictions.
- *
- * The bypass is for this process only — the shell process is not subject to the
- * same enforcement — but the app still reflects over TetheringManager to report
- * state.
- */
 class App : Application() {
 
-    /**
-     * Owned here rather than by a ViewModel: the session service reads the
-     * logging setting too, and it has no ViewModel to read it from.
-     */
     val settingsStore: SettingsStore by lazy { SettingsStore(this) }
 
     override fun onCreate() {
         super.onCreate()
         instance = this
 
-        // Before anything that might log: the app process cannot write to the
-        // shell's directory, so its entries would go nowhere until this runs.
         SessionLog.useAppStorage(filesDir)
         applyLoggingSetting()
 
         liftHiddenApiRestrictions()
     }
 
-    /**
-     * The store is read asynchronously, so entries written before it arrives
-     * follow the default. The window is short and the default is on, erring
-     * toward recording rather than dropping a launch failure.
-     */
     private fun applyLoggingSetting() {
         CoroutineScope(Dispatchers.IO).launch {
             val isLogging = settingsStore.settings.first().isLogging
@@ -47,12 +29,6 @@ class App : Application() {
         }
     }
 
-    /**
-     * Android 9+ blocks reflection onto non-SDK members. HiddenApiBypass clears
-     * that for this process; without it the TestNetworkManager lookups throw
-     * NoSuchMethodException that looks identical to the API genuinely being
-     * absent — a distinction the probes exist to make.
-     */
     private fun liftHiddenApiRestrictions() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return
         HiddenApiBypass.addHiddenApiExemptions("Landroid/net/", "L")

--- a/app/src/main/java/dev/shizzi/CompatibilityCheck.kt
+++ b/app/src/main/java/dev/shizzi/CompatibilityCheck.kt
@@ -3,37 +3,14 @@ package dev.shizzi
 import android.content.Context
 import org.json.JSONObject
 
-/**
- * The capabilities onboarding reports on, in the order it lists them.
- *
- * Only the two that separate a working device from a broken one. Starting the
- * hotspot has the lowest floor of the three the app needs and is reached by two
- * different calls, so asking about it answers nothing a user can act on; see
- * docs/android-compatibility.md.
- */
 enum class Capability { TEST_NETWORK, PREFER_TEST_NETWORKS }
 
-/**
- * Whether one capability is present, and the evidence either way.
- *
- * [detail] carries the verbatim reason a check failed, for the same reason
- * [ProbeResult] does: generic error text is what makes a failure unactionable.
- */
 data class CapabilityResult(
     val capability: Capability,
     val isPresent: Boolean,
     val detail: String,
 )
 
-/**
- * Answers whether this device can run the app, without doing anything to it.
- *
- * Distinct from [ProbeRunner], which answers the same question by running a
- * whole session — it creates a TUN, starts the hotspot, and takes the tethering
- * stack through upstream selection. That is the right check to export when
- * something is wrong and the wrong one to make a user sit through on first
- * launch.
- */
 class CompatibilityCheck(private val context: Context) {
 
     fun run(): List<CapabilityResult> = Capability.entries.map { capability ->
@@ -43,10 +20,6 @@ class CompatibilityCheck(private val context: Context) {
         }
     }
 
-    /**
-     * The class alone is not enough: it survives on builds where the service
-     * behind it has been trimmed, and the session needs the instance.
-     */
     private fun checkTestNetwork(): CapabilityResult {
         val api = TestNetworkApi(context)
 
@@ -60,12 +33,6 @@ class CompatibilityCheck(private val context: Context) {
         )
     }
 
-    /**
-     * Resolved but never invoked. Calling it would raise the preference on a
-     * device the user has not started a session on, and the resolution is what
-     * the answer turns on — the call itself is accepted wherever the method
-     * exists at this UID.
-     */
     private fun checkPreferTestNetworks(): CapabilityResult {
         val failure = TetheringPreferenceApi(context).resolutionFailure()
 
@@ -77,7 +44,6 @@ class CompatibilityCheck(private val context: Context) {
     }
 }
 
-/** The JSON [CompatibilityCheck] crosses the binder as. */
 fun List<CapabilityResult>.toJson(): String = JSONObject().apply {
     this@toJson.forEach { result ->
         put(
@@ -90,13 +56,6 @@ fun List<CapabilityResult>.toJson(): String = JSONObject().apply {
     }
 }.toString()
 
-/**
- * Reads back what [toJson] wrote.
- *
- * A capability the report does not mention is absent rather than skipped: an
- * older shell daemon answers without it, and treating silence as present would
- * clear a device the app cannot run on.
- */
 fun parseCapabilities(report: String): List<CapabilityResult> {
     val parsed = runCatching { JSONObject(report) }.getOrNull()
 

--- a/app/src/main/java/dev/shizzi/CompatibilityState.kt
+++ b/app/src/main/java/dev/shizzi/CompatibilityState.kt
@@ -1,39 +1,15 @@
 package dev.shizzi
 
-/**
- * Where the compatibility check is.
- *
- * Separate from [DiagnosticsState] despite the shape rhyming: that one carries
- * a report meant to be exported and read by a developer, this one carries per
- * capability answers a user is shown. Folding them would make every consumer
- * ask which kind of run produced the state it holds.
- */
 sealed interface CompatibilityState {
 
-    /** Nothing has been asked yet. The step offers Check. */
     data object Idle : CompatibilityState
 
     data object Checking : CompatibilityState
 
-    /**
-     * [results] holds an entry per [Capability], in declaration order, whether
-     * or not the check could answer it.
-     */
     data class Complete(val results: List<CapabilityResult>) : CompatibilityState
 
-    /**
-     * The check could not run at all — Shizuku went away, or the daemon is
-     * stale. Distinct from a run that answered "not compatible": one is a
-     * verdict about the device, the other is the app failing to reach it.
-     */
     data class Failed(val problem: String) : CompatibilityState
 }
 
-/**
- * True only once every capability has answered present.
- *
- * A check that never ran is not compatibility, so [Idle] and [Failed] are false
- * rather than unknown — the button past this step reads the same value.
- */
 val CompatibilityState.isCompatible: Boolean
     get() = this is CompatibilityState.Complete && results.all { it.isPresent }

--- a/app/src/main/java/dev/shizzi/Diagnostics.kt
+++ b/app/src/main/java/dev/shizzi/Diagnostics.kt
@@ -1,25 +1,11 @@
 package dev.shizzi
 
-/**
- * Where a diagnostics run is.
- *
- * Kept out of [SessionUiState] because a probe run holds no session and the two
- * overlap in time — diagnostics are startable while a session is up, and one
- * state cannot describe both.
- */
 sealed interface DiagnosticsState {
 
-    /** Nothing has run this visit, or the last result has been dismissed. */
     data object Idle : DiagnosticsState
 
-    /** The settings screen is inert while this holds. */
     data object Running : DiagnosticsState
 
-    /**
-     * [report] is carried rather than re-read: the shell wrote it to [path]
-     * under a different uid, so the app cannot read it back. Holding the
-     * string is what makes an export possible at all.
-     */
     data class Complete(val report: String, val path: String) : DiagnosticsState
 
     data class Failed(val problem: String) : DiagnosticsState

--- a/app/src/main/java/dev/shizzi/DownstreamControl.kt
+++ b/app/src/main/java/dev/shizzi/DownstreamControl.kt
@@ -7,11 +7,6 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 
-/**
- * TETHER_ERROR_* values from framework-tethering.jar on the API 36 device under
- * test. The framework reports bare ints, so R7.5's verbatim errors would
- * otherwise reach the user as "error=14".
- */
 private val TETHER_ERROR_NAMES = mapOf(
     0 to "NO_ERROR",
     1 to "UNKNOWN_IFACE",
@@ -41,55 +36,24 @@ private fun describeTetherError(code: Int?): String {
     return "error=$code TETHER_ERROR_$name"
 }
 
-/**
- * Stops and starts Wi-Fi tethering through TetheringManager.
- *
- * R4.1 wants setPreferTestNetworks(true) immediately *before* the downstream
- * starts, because the framework will not move an already-selected upstream: on
- * device the preference is accepted and the TUN appears in the quota table, yet
- * wlan0 stays selected past a 15s settle. Restarting under the preference
- * (R4.4) is the only path that re-runs selection.
- *
- * Reflection because there is no `cmd tethering`; shell holds TETHER_PRIVILEGED.
- */
 class DownstreamControl(private val context: Context) {
 
-    /**
-     * TetheringManager captures the caller package at construction from
-     * getOpPackageName(), and TetheringService rejects a mismatch with "Package
-     * name android does not match UID 2000" — hence the rebased context.
-     */
     private val tetheringManager: Any
         get() = context.getSystemService("tethering")
             ?: error("tethering service unavailable")
 
-    /** Package the framework will attribute these calls to. */
     val opPackageName: String get() = context.opPackageName
 
     private val managerClass: Class<*> get() = Class.forName("android.net.TetheringManager")
 
-    /** TETHERING_WIFI, stable across releases. */
     private val wifiTetheringType = 0
 
-    /**
-     * A fixed settle rather than a callback, whose shape has changed across
-     * releases when all this needs is the downstream down before a restart.
-     *
-     * @return whether the call was accepted, which is not the hotspot being
-     *   down — teardown needs [DownstreamInspector] for that distinction.
-     */
     fun stopWifiTethering(): Boolean = runCatching {
         val method = managerClass.getMethod("stopTethering", Int::class.javaPrimitiveType)
         method.invoke(tetheringManager, wifiTetheringType)
         Thread.sleep(STOP_SETTLE_MS)
     }.isSuccess
 
-    /**
-     * TetheringManager first: the earlier NO_CHANGE_TETHERING_PERMISSION came
-     * from requesting an entitlement exemption, not from the start itself.
-     * WifiManager is the fallback, though startSoftAp/startTetheredHotspot both
-     * enforce MAINLINE_NETWORK_STACK, which shell can never hold.
-     */
     fun startWifiTethering(): Pair<Boolean, String> {
         val viaTethering = startViaTetheringManager()
         if (viaTethering.first) return viaTethering
@@ -101,10 +65,6 @@ class DownstreamControl(private val context: Context) {
         }
     }
 
-    /**
-     * Null config uses the device's saved hotspot settings, per section 1.2,
-     * which excludes SSID/password/band control.
-     */
     private fun startViaWifiManager(): Pair<Boolean, String> = runCatching {
         val wifiManager = context.getSystemService(Context.WIFI_SERVICE)
             ?: return false to "wifi service unavailable"
@@ -121,10 +81,6 @@ class DownstreamControl(private val context: Context) {
         false to "startTetheredHotspot: ${failure.cause?.message ?: failure.message}"
     }
 
-    /**
-     * Exempt request first, then plain — as VPNHotspot does, since the
-     * exemption is what a non-privileged caller cannot have.
-     */
     private fun startViaTetheringManager(): Pair<Boolean, String> {
         val exempt = startTetheringRequest(isExemptFromEntitlement = true)
         if (exempt.first) return exempt
@@ -154,12 +110,6 @@ class DownstreamControl(private val context: Context) {
         }.getOrElse { false to "startTethering: ${it.message}" }
     }
 
-    /**
-     * setExemptFromEntitlementCheck is the expensive option: in
-     * hasTetherChangePermission it gates a branch requiring NETWORK_STACK or
-     * NETWORK_SETTINGS, denying before the TETHER_PRIVILEGED check shell would
-     * pass. No exemption keeps the caller on the path shell can satisfy.
-     */
     private fun buildTetheringRequest(isExemptFromEntitlement: Boolean): Any {
         val builderClass = Class.forName("android.net.TetheringManager\$TetheringRequest\$Builder")
         val builder = builderClass
@@ -188,10 +138,6 @@ class DownstreamControl(private val context: Context) {
         method.invoke(tetheringManager, request, mainExecutor(), callback)
     }
 
-    /**
-     * A proxy for the hidden StartTetheringCallback, reporting through [result]
-     * so the caller can surface the framework's own error code (R7.5).
-     */
     private fun createStartCallback(latch: CountDownLatch, result: Array<String>): Any? =
         runCatching {
             val callbackClass =

--- a/app/src/main/java/dev/shizzi/DownstreamInspector.kt
+++ b/app/src/main/java/dev/shizzi/DownstreamInspector.kt
@@ -1,25 +1,12 @@
 package dev.shizzi
 
-/**
- * Reports whether any downstream is still tethered.
- *
- * Separate from DownstreamControl, which asks the framework to change state:
- * stopTethering returning says only that the request was accepted, and a
- * hotspot still up after teardown is the dangerous case — tethering falls back
- * to the physical upstream and clients keep browsing through it.
- */
 class DownstreamInspector(private val inspector: UpstreamInspector = UpstreamInspector()) {
 
     private var cachedCount = 0
     private var lastReadAt = 0L
 
-    /**
-     * Kept apart from [cachedCount] so the log records changes rather than
-     * readings — a line per poll would bury the file before the size cap.
-     */
     private var loggedCount = 0
 
-    /** @return null when nothing is tethered, else what is still up. */
     fun findTetheredDownstream(): String? {
         val observation = inspector.observe()
         if (observation.didTimeout) return "dumpsys tethering timed out; downstream state unknown"
@@ -35,17 +22,6 @@ class DownstreamInspector(private val inspector: UpstreamInspector = UpstreamIns
         }
     }
 
-    /**
-     * How many devices are on the hotspot.
-     *
-     * Rate-limited: the dump costs ~127ms of subprocess and status polls
-     * continuously, which would spend the polling budget on a number that
-     * changes when someone walks into the room. Bytes come from
-     * [InterfaceCounters] instead, which is what lets them move at a useful rate.
-     *
-     * @return 0 when nothing is tethered or the dump could not be read — this
-     *   feeds a display, and an unreadable dump is not worth failing over.
-     */
     fun countDevices(): Int {
         val now = System.currentTimeMillis()
         if (now - lastReadAt < REFRESH_INTERVAL_MS) return cachedCount
@@ -59,7 +35,6 @@ class DownstreamInspector(private val inspector: UpstreamInspector = UpstreamIns
         return cachedCount
     }
 
-    /** Transitions only; a steady count says nothing new. */
     private fun logCountChange(count: Int) {
         if (count == loggedCount) return
 
@@ -68,13 +43,6 @@ class DownstreamInspector(private val inspector: UpstreamInspector = UpstreamIns
         SessionLog.info("client $direction: $count now on the hotspot")
     }
 
-    /**
-     * Read from `dumpsys wifi`, not `dumpsys tethering`, whose candidate
-     * structures both describe the past: NAT rules keep entries for minutes
-     * after a device leaves (observed at 176s), and "Client Information:" is a
-     * DHCP lease list. The Wi-Fi layer is where association is known, and its
-     * count returned to 0 the moment a test device disconnected.
-     */
     private fun parseDeviceCount(output: String): Int =
         CONNECTED_CLIENTS_PATTERN.findAll(output)
             .mapNotNull { match -> match.groupValues[1].toIntOrNull() }
@@ -82,24 +50,13 @@ class DownstreamInspector(private val inspector: UpstreamInspector = UpstreamIns
             ?: 0
 
     private companion object {
-        /**
-         * The live state line, "wlan1 - TetheredState - lastError = 0", not the
-         * timestamped event log below it — that names TETHERED interfaces long
-         * after teardown, reporting a stopped hotspot as running.
-         */
+
         private val TETHERED_STATE_PATTERN =
             Regex("""^\s*(\w+)\s+-\s+TetheredState\s+-""")
 
-        /**
-         * "getConnectedClientList().size(): 0" — current state, unlike the
-         * `num_connected_clients=` history below it, where reading means
-         * reading whichever transition printed last. Largest wins, because a
-         * device serving several AP instances prints this once each.
-         */
         private val CONNECTED_CLIENTS_PATTERN =
             Regex("""getConnectedClientList\(\)\.size\(\):\s*(\d+)""")
 
-        /** Staleness bought in exchange for a cheap poll; nobody is waiting on it. */
         private const val REFRESH_INTERVAL_MS = 10_000L
     }
 }

--- a/app/src/main/java/dev/shizzi/HiddenApi.kt
+++ b/app/src/main/java/dev/shizzi/HiddenApi.kt
@@ -12,13 +12,6 @@ import android.os.ParcelFileDescriptor
 import java.lang.reflect.Method
 import java.net.InetAddress
 
-/**
- * Every hidden/system API this depends on, in one place.
- *
- * Exit criterion #4 requires a written record of which hidden APIs were touched.
- * Each [HiddenApiPath] entry is both the documentation and the thing invoked, so
- * the two cannot drift; see also docs/hidden-api-record.md.
- */
 data class HiddenApiPath(
     val id: String,
     val className: String,
@@ -27,14 +20,6 @@ data class HiddenApiPath(
     val notes: String,
 )
 
-/**
- * The reflection paths, as data. Resolution failures are reported per-path so a
- * single missing method identifies itself instead of collapsing the whole run.
- *
- * `since` is the earliest API level the path was verified on, and the two
- * subsystems here do not share a floor. Which releases the app as a whole can
- * run on is a separate question, worked out in docs/android-compatibility.md.
- */
 object HiddenApiCatalog {
     val paths: List<HiddenApiPath> = listOf(
         HiddenApiPath(
@@ -142,18 +127,9 @@ object HiddenApiCatalog {
     )
 }
 
-/**
- * Not cosmetic: tethering's getIPv6Interface returns null unless the upstream
- * has an IPv6 DNS server, and IPv6 is then never provisioned downstream.
- */
 val TEST_NETWORK_DNS_SERVERS: List<InetAddress>
     get() = listOf("2001:4860:4860::8888", "8.8.8.8").map(InetAddress::getByName)
 
-/**
- * Kotlin cannot call the package-private constructor even with hidden-API
- * exemptions lifted: the restriction is compile-time visibility, not the
- * runtime greylist.
- */
 fun buildLinkAddress(address: InetAddress, prefixLength: Int): LinkAddress {
     val constructor = LinkAddress::class.java
         .getDeclaredConstructor(InetAddress::class.java, Int::class.javaPrimitiveType)
@@ -161,29 +137,17 @@ fun buildLinkAddress(address: InetAddress, prefixLength: Int): LinkAddress {
     return constructor.newInstance(address, prefixLength)
 }
 
-/**
- * Falls back to the known AOSP value only when reflection fails, and the caller
- * reports which path was taken — a silent mismatch would masquerade as a
- * working test network.
- */
 fun resolveTransportTest(): Int = runCatching {
     NetworkCapabilities::class.java.getField("TRANSPORT_TEST").getInt(null)
 }.getOrDefault(TRANSPORT_TEST_AOSP_FALLBACK)
 
-/** TRANSPORT_TEST as defined on AOSP; used only if the field cannot be read. */
 const val TRANSPORT_TEST_AOSP_FALLBACK = 7
 
-/** Outcome of resolving one hidden API path. */
 sealed interface Resolution {
     data class Found(val path: HiddenApiPath) : Resolution
     data class Missing(val path: HiddenApiPath, val reason: String) : Resolution
 }
 
-/**
- * Construction resolves nothing; each accessor resolves lazily and reports its
- * own failure, so a probe run can tell "class absent" from "method renamed"
- * from "permission denied".
- */
 class TestNetworkApi(private val context: Context) {
 
     private val managerClass: Class<*>? = runCatching {
@@ -192,13 +156,12 @@ class TestNetworkApi(private val context: Context) {
 
     @SuppressLint("WrongConstant")
     private val manager: Any? = runCatching {
-        // "test_network" is TestNetworkManager.TEST_NETWORK_SERVICE, itself hidden.
+
         context.getSystemService("test_network")
     }.getOrNull()
 
     val isAvailable: Boolean get() = managerClass != null && manager != null
 
-    /** Resolves every catalog entry so the report can list what exists on this build. */
     fun resolveAll(): List<Resolution> = HiddenApiCatalog.paths.map { path ->
         resolveOne(path)
     }
@@ -219,11 +182,6 @@ class TestNetworkApi(private val context: Context) {
         else -> Resolution.Missing(path, "no declared constructor on ${path.className}")
     }
 
-    /**
-     * Members are looked up as methods *and* fields: the catalog holds constants
-     * such as TRANSPORT_TEST alongside methods, and checking only declaredMethods
-     * reports every constant as missing.
-     */
     private fun resolveMethodOrField(owner: Class<*>, path: HiddenApiPath): Resolution {
         val hasMethod = owner.declaredMethods.any { it.name == path.memberName }
         val hasField = owner.declaredFields.any { it.name == path.memberName }
@@ -233,12 +191,6 @@ class TestNetworkApi(private val context: Context) {
         }
     }
 
-    /**
-     * Creates a TUN carrying [addresses].
-     *
-     * Tries the Collection overload first, then the array overload, because
-     * builds disagree on which one they carry.
-     */
     fun createTunInterface(addresses: List<LinkAddress>): TunHandle {
         val instance = manager ?: error("createTunInterface: test_network service unavailable")
         val owner = managerClass ?: error("createTunInterface: TestNetworkManager class absent")
@@ -273,17 +225,6 @@ class TestNetworkApi(private val context: Context) {
         method.invoke(instance, argument)
     }.getOrNull()
 
-    /**
-     * Registers [interfaceName] as a test network bound to [binder]'s lifetime.
-     *
-     * The LinkProperties overload carries [dnsServers] because tethering's
-     * getIPv6Interface requires hasIpv6DnsServer() and the plain overload
-     * leaves that empty. Only the DNS servers survive — the framework
-     * overwrites the interface name and link addresses.
-     *
-     * Falls back to the plain overload where the other is absent, so such a
-     * build still gets a working IPv4 session.
-     */
     fun setupTestNetwork(interfaceName: String, dnsServers: List<InetAddress>, binder: IBinder) {
         val instance = manager ?: error("setupTestNetwork: test_network service unavailable")
         val owner = managerClass ?: error("setupTestNetwork: TestNetworkManager class absent")
@@ -314,7 +255,6 @@ class TestNetworkApi(private val context: Context) {
         method.invoke(instance, request.first, true, request.second)
     }.isSuccess
 
-    /** Tears down the framework-side test network for [network]. */
     fun teardownTestNetwork(network: Network) {
         val instance = manager ?: return
         val owner = managerClass ?: return
@@ -323,7 +263,6 @@ class TestNetworkApi(private val context: Context) {
     }
 }
 
-/** Wrapper over a hidden TestNetworkInterface instance. */
 class TunHandle(private val delegate: Any) {
 
     val interfaceName: String
@@ -339,10 +278,6 @@ class TunHandle(private val delegate: Any) {
         }
 }
 
-/**
- * TetheringManager.setPreferTestNetworks, the single call the whole approach
- * rests on — so its absence is reported rather than swallowed.
- */
 class TetheringPreferenceApi(private val context: Context) {
 
     private fun resolveMethod(): Method {
@@ -358,19 +293,11 @@ class TetheringPreferenceApi(private val context: Context) {
         resolveMethod().invoke(tetheringManager(), prefer)
     }
 
-    /**
-     * Whether the method is reachable here, without calling it.
-     *
-     * @return null when it resolves, else why it did not — the class being
-     *   absent and the method being absent from it are different builds, and
-     *   collapsing them to a boolean loses which.
-     */
     fun resolutionFailure(): String? = runCatching { resolveMethod() }.fold(
         onSuccess = { null },
         onFailure = { failure -> "${failure.javaClass.simpleName}: ${failure.message}" },
     )
 }
 
-/** ConnectivityManager is public API; kept here so the probe reads in one place. */
 fun Context.connectivityManager(): ConnectivityManager =
     getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager

--- a/app/src/main/java/dev/shizzi/HomeScreen.kt
+++ b/app/src/main/java/dev/shizzi/HomeScreen.kt
@@ -23,10 +23,6 @@ import dev.shizzi.ui.rememberNavigator
 import dev.shizzi.ui.rememberToastState
 import dev.shizzi.ui.theme.ThemeChoice
 
-/**
- * Everything the screens need from the ViewModel, grouped so routing does not
- * take a parameter per callback.
- */
 data class AppActions(
     val onToggle: () -> Unit,
     val onCancel: () -> Unit,
@@ -39,12 +35,6 @@ data class AppActions(
     val onRestartOnboarding: () -> Unit,
 )
 
-/**
- * Routes between the three screens.
- *
- * Log and Settings are screens rather than overlays, so the system back
- * gesture returns to Home rather than leaving the app.
- */
 @Composable
 fun HomeScreen(
     state: SessionUiState,
@@ -55,8 +45,6 @@ fun HomeScreen(
     val current = rememberNavigator()
     val goHome = { current.value = Screen.HOME }
 
-    // Back from the log returns to settings, which is now the only way into it
-    // — sending it to Home would drop the user two levels from one gesture.
     val goBack = {
         current.value = if (current.value == Screen.LOG) Screen.SETTINGS else Screen.HOME
     }
@@ -69,9 +57,6 @@ fun HomeScreen(
         onRequestPermission = actions.onRequestPermission,
     )
 
-    // Not from the settings screen: a run outlives a visit to it, and that
-    // toast would vanish the moment the user navigated home to wait — taking
-    // the export button with it.
     DiagnosticsToast(
         state = diagnostics,
         toasts = toasts,
@@ -105,8 +90,7 @@ fun HomeScreen(
                 actions = LogActions(
                     onClear = actions.onClearLog,
                     onEnableLogging = { actions.onSetLogging(true) },
-                    // Goes home as well as starting: the status glyph and the
-                    // button are what report progress, and neither is here.
+
                     onStartSession = {
                         goHome()
                         actions.onToggle()
@@ -125,9 +109,6 @@ fun HomeScreen(
             )
         }
 
-        // Last child, so it draws over whichever screen is showing. App-level
-        // rather than per-screen: an error raised on Home is still worth seeing
-        // after navigating to the log to investigate it.
         ToastHost(
             state = toasts,
             modifier = Modifier.align(Alignment.BottomCenter).systemBarsPadding(),

--- a/app/src/main/java/dev/shizzi/InterfaceCounters.kt
+++ b/app/src/main/java/dev/shizzi/InterfaceCounters.kt
@@ -2,41 +2,19 @@ package dev.shizzi
 
 import java.io.File
 
-/**
- * Reads an interface's byte counters straight from the kernel, keeping the byte
- * half of a status read off `dumpsys`: a subprocess costs ~127ms on device
- * (~75ms of it fork/exec) against a few hundred microseconds here, and status
- * polls for the life of a session.
- *
- * These are the counters the tethering BPF stats report — sampled together
- * across a 52 MB transfer, the TUN's rx and ForwardedStats' rxb tracked to
- * within a few kilobytes.
- */
 object InterfaceCounters {
 
-    /**
-     * @param interfaceName the session's own TUN, named rather than matched by
-     *   prefix: a stale TUN can still be present (a device showed testtun24
-     *   beside the live testtun25) and summing both reports traffic this
-     *   session never carried.
-     *
-     * @return zeroes when the interface is absent — the honest reading for a
-     *   session that has not built its TUN yet.
-     */
     fun read(interfaceName: String): Traffic {
         val line = runCatching { File(PROC_NET_DEV).readLines() }
             .getOrDefault(emptyList())
             .firstOrNull { it.trimStart().startsWith("$interfaceName:") }
             ?: return Traffic()
 
-        // Split on the colon, not whitespace: a wide enough counter fills the
-        // column and runs into the name, "testtun25:41573895 37687 0 ...".
         val fields = line.substringAfter(':').trim().split(WHITESPACE)
         if (fields.size <= TX_BYTES_FIELD) return Traffic()
 
         return Traffic(
-            // rx/tx are named from the interface's side, inverting the user's:
-            // bytes the TUN received are bytes the tethered device downloaded.
+
             down = fields[RX_BYTES_FIELD].toLongOrNull() ?: 0,
             up = fields[TX_BYTES_FIELD].toLongOrNull() ?: 0,
         )
@@ -45,7 +23,6 @@ object InterfaceCounters {
     private val WHITESPACE = Regex("""\s+""")
     private const val PROC_NET_DEV = "/proc/net/dev"
 
-    /** Field order is fixed by the kernel: rx bytes first, tx bytes ninth. */
     private const val RX_BYTES_FIELD = 0
     private const val TX_BYTES_FIELD = 8
 }

--- a/app/src/main/java/dev/shizzi/MainActivity.kt
+++ b/app/src/main/java/dev/shizzi/MainActivity.kt
@@ -22,7 +22,6 @@ class MainActivity : ComponentActivity() {
 
     private val viewModel: SessionViewModel by viewModels()
 
-    /** R1.3: permission arrives via this listener, never auto-requested at launch. */
     private val permissionListener =
         Shizuku.OnRequestPermissionResultListener { _, _ -> viewModel.refreshShizukuState() }
 
@@ -32,10 +31,6 @@ class MainActivity : ComponentActivity() {
     private val binderDeadListener =
         Shizuku.OnBinderDeadListener { viewModel.refreshShizukuState() }
 
-    /**
-     * Once at launch, never blocking: the service runs either way, so a denial
-     * costs the user visibility rather than function.
-     */
     private val notificationPermission =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
 
@@ -51,9 +46,6 @@ class MainActivity : ComponentActivity() {
             ShizziTheme(choice = loaded.theme) {
                 val colors = ShizziTheme.colors
 
-                // Edge-to-edge makes the bar icons the app's responsibility, or
-                // they stay light-on-light and invisible. Keyed on the resolved
-                // theme, since the setting can override the system's.
                 SideEffect {
                     WindowCompat.getInsetsController(window, window.decorView)
                         .isAppearanceLightStatusBars = !colors.isDark
@@ -91,16 +83,9 @@ class MainActivity : ComponentActivity() {
             }
         }
 
-        // After setContent: the listener attaches to the view setContent
-        // installs, which does not exist before it runs.
         holdFirstFrameUntilSettingsLoad()
     }
 
-    /**
-     * Holds the window until the stored theme is known: otherwise it paints
-     * under the default for a frame or two while DataStore reads, flashing dark
-     * on every launch for a user who chose Light on a dark-mode phone.
-     */
     private fun holdFirstFrameUntilSettingsLoad() {
         val content = findViewById<View>(android.R.id.content)
 

--- a/app/src/main/java/dev/shizzi/ProbeReport.kt
+++ b/app/src/main/java/dev/shizzi/ProbeReport.kt
@@ -3,21 +3,8 @@ package dev.shizzi
 import org.json.JSONArray
 import org.json.JSONObject
 
-/**
- * Outcome of a single probe question.
- *
- * SKIPPED exists so a report stays readable when an early probe fails: later
- * probes record that they never ran rather than reporting a misleading failure.
- */
 enum class ProbeOutcome { PASS, FAIL, SKIPPED }
 
-/**
- * One answered viability question.
- *
- * [detail] carries the verbatim evidence — an interface name, an exception
- * message, a dumpsys excerpt — because R7.5 forbids generic error text and the
- * whole value of a probe report is in the specifics.
- */
 data class ProbeResult(
     val id: String,
     val question: String,
@@ -25,7 +12,6 @@ data class ProbeResult(
     val detail: String,
 )
 
-/** Accumulates results in order and renders the JSON the app displays. */
 class ProbeReportBuilder {
 
     private val results = mutableListOf<ProbeResult>()
@@ -53,13 +39,6 @@ class ProbeReportBuilder {
         hiddenApiFindings += resolutions
     }
 
-    /**
-     * Records the outcome of releasing the session as spec case T-2.
-     *
-     * An empty problem list is a PASS worth stating: T-2 asks whether the run
-     * leaves an orphaned testtun or a leaked fd behind, and silence would be
-     * indistinguishable from never having checked.
-     */
     fun recordReleaseProblems(problems: List<String>) {
         record(
             id = "T-2",
@@ -72,7 +51,6 @@ class ProbeReportBuilder {
         )
     }
 
-    /** True when no probe failed; skipped probes do not count as failures. */
     val hasFailure: Boolean get() = results.any { it.outcome == ProbeOutcome.FAIL }
 
     fun build(environment: JSONObject): String {

--- a/app/src/main/java/dev/shizzi/ProbeRunner.kt
+++ b/app/src/main/java/dev/shizzi/ProbeRunner.kt
@@ -10,12 +10,6 @@ import android.util.Log
 import org.json.JSONObject
 import java.net.InetAddress
 
-/**
- * Executes the viability probe sequence inside the Shizuku shell process.
- *
- * Ordering matters: each probe is a precondition for the next, so a failure
- * marks the remainder SKIPPED rather than producing cascading false failures.
- */
 class ProbeRunner(private val context: Context) {
 
     private val testNetworkApi = TestNetworkApi(context)
@@ -23,19 +17,8 @@ class ProbeRunner(private val context: Context) {
     private val teardown = SessionTeardown(context)
     private var resources: SessionResources? = null
 
-    /**
-     * Whether this run started the hotspot, and so owes stopping it — killing
-     * one the user brought up would make a diagnostic destructive.
-     */
     private var didStartDownstream = false
 
-    /**
-     * Releases in its own finally rather than leaving it to [teardown], which
-     * is a separate binder call behind its own button: un-torn-down runs left
-     * their test networks alive, stacking orphaned testtun interfaces (17
-     * through 21 across five runs) that CMD_RETRY_UPSTREAM then reselected
-     * among — which is what made Q5 read an interface it did not own.
-     */
     fun run(attemptTethering: Boolean, availabilityTimeoutMs: Int): String {
         val report = ProbeReportBuilder()
         report.recordHiddenApiResolutions(testNetworkApi.resolveAll())
@@ -53,15 +36,6 @@ class ProbeRunner(private val context: Context) {
         return report.build(environment())
     }
 
-    /**
-     * Undoes everything the run changed, recording problems in the report as
-     * T-2 evidence rather than only in the log — a silent release would hide
-     * exactly the leak that case is about.
-     *
-     * Order matches [TetherSession.stop], where the same hazards are documented:
-     * downstream first, fail-closed per R6.1, then the upstream preference back
-     * *while the TUN still exists*, then the interface.
-     */
     private fun releaseSession(report: ProbeReportBuilder) {
         val downstreamProblem = when {
             didStartDownstream -> teardown.releaseDownstream()
@@ -82,7 +56,6 @@ class ProbeRunner(private val context: Context) {
         )
     }
 
-    /** Q0/Q1: are we actually shell, with the service present? */
     private fun probeIdentityAndPlatform(report: ProbeReportBuilder): Boolean {
         val uid = Process.myUid()
         val isPrivilegedUid = uid == SHELL_UID || uid == ROOT_UID
@@ -127,15 +100,6 @@ class ProbeRunner(private val context: Context) {
         )
     }
 
-    /**
-     * Sets the preference before the TUN exists, because setPreferTestNetworks
-     * only writes the flag — the disassembly is a Handler.post then
-     * sendTetherResult, no reselection — and selection re-runs only on an
-     * event. The flag must already be true when the test network arrives, or
-     * that arrival is evaluated with it false and nothing revisits it.
-     *
-     * Q4 still records the call R4.1 asks about; this one is about ordering.
-     */
     private fun preferTestNetworksBeforeTunExists(report: ProbeReportBuilder) {
         runCatching { TetheringPreferenceApi(context).setPreferTestNetworks(true) }
             .onFailure { failure ->
@@ -147,22 +111,11 @@ class ProbeRunner(private val context: Context) {
             }
     }
 
-    /**
-     * Restarts the downstream before the TUN exists, so its arrival is seen.
-     *
-     * startTethering runs startObserveUpstreamNetworks, whose stop() clears
-     * mNetworkMap and re-registers: a TUN created beforehand has already fired
-     * onAvailable and is dropped by that wipe, never re-delivered. Creating it
-     * after puts its arrival inside the new callback's window, the only way to
-     * hold both conditions at once — preference already true, network in the map.
-     */
     private fun restartDownstreamBeforeTun(report: ProbeReportBuilder) {
         val control = DownstreamControl(context)
         val didStop = control.stopWifiTethering()
         val (didStart, startDetail) = control.startWifiTethering()
 
-        // Even when the start is rejected: "stopped, then failed to start"
-        // still leaves the radio in a state the run changed.
         didStartDownstream = didStop || didStart
 
         if (!didStart) {
@@ -191,10 +144,6 @@ class ProbeRunner(private val context: Context) {
         probeTetheringPreference(report, interfaceName, attemptTethering)
     }
 
-    /**
-     * Before tethering begins: clients associating first would send into a TUN
-     * nothing drains.
-     */
     private fun probeDatapath(report: ProbeReportBuilder) {
         val group = resources
         if (group == null) {
@@ -212,18 +161,6 @@ class ProbeRunner(private val context: Context) {
         )
     }
 
-    /**
-     * Q8: does a listen callback ever fire for the test network?
-     *
-     * mNetworkMap is populated only from the monitor's own NetworkCallback —
-     * handleAvailable inserts, handleNetCap returns early for anything not
-     * already there. Without onAvailable, findFirstTestNetwork has nothing to
-     * find whatever mPreferTestNetworks says.
-     *
-     * Registers the same request the monitor builds on API 33+
-     * (clearCapabilities, forbidding LOCAL_NETWORK) and reports whether the TUN
-     * is delivered — the value every previous theory assumed and none measured.
-     */
     private fun probeUpstreamCallback(report: ProbeReportBuilder, interfaceName: String) {
         val network = resources?.acquiredNetwork
         if (network == null) {
@@ -240,10 +177,6 @@ class ProbeRunner(private val context: Context) {
         )
     }
 
-    /**
-     * Returns delivery plus the verbatim outcome: a rejected registration and a
-     * silent non-delivery are different findings.
-     */
     private fun awaitCallbackDelivery(interfaceName: String): Pair<Boolean, String> {
         val manager = context.connectivityManager()
         val latch = java.util.concurrent.CountDownLatch(1)
@@ -279,8 +212,7 @@ class ProbeRunner(private val context: Context) {
 
     private fun onTunFailed(report: ProbeReportBuilder, failure: Throwable) {
         val message = "${failure.javaClass.simpleName}: ${failure.message}"
-        // Distinguish "TUN never created" from "created but never became available":
-        // they point at different framework problems.
+
         val didCreateTun = resources?.interfaceName != null
         when {
             didCreateTun -> {
@@ -300,23 +232,6 @@ class ProbeRunner(private val context: Context) {
         report.recordSkip("Q6", QUESTION_IPV6, "no test network")
     }
 
-    /**
-     * Q3b: is the test network recognisable to the stack's test-network branch?
-     *
-     * UpstreamNetworkMonitor.getCurrentPreferredUpstream on this build reads:
-     *
-     *     if (mPreferTestNetworks) {
-     *         state = findFirstTestNetwork(mNetworkMap.values());
-     *         if (state != null) return state;
-     *     }
-     *
-     * That returns before any INTERNET, cellular, or DUN check, and
-     * findFirstTestNetwork filters on TRANSPORT_TEST alone — so eligibility is
-     * the test transport, not NET_CAPABILITY_INTERNET, which TestNetworkService
-     * never grants anyway. INTERNET is still reported because without it the
-     * network cannot serve as a general default route, which constrains the
-     * datapath even though it does not block upstream selection.
-     */
     private fun probeUpstreamEligibility(report: ProbeReportBuilder) {
         val network = resources?.acquiredNetwork
         if (network == null) {
@@ -343,13 +258,6 @@ class ProbeRunner(private val context: Context) {
         )
     }
 
-    /**
-     * [attemptTethering] false no longer skips Q5: it passed once on a run
-     * where the downstream was already up, and failed on every run that
-     * restarted it, so "observe without restarting" is the comparison that
-     * separates the two. Skipping measured nothing and hid the one condition
-     * under which it is known to work.
-     */
     private fun probeTetheringPreference(
         report: ProbeReportBuilder,
         interfaceName: String,
@@ -367,9 +275,6 @@ class ProbeRunner(private val context: Context) {
             },
         )
 
-        // The restart, when requested, already happened before the TUN was
-        // created, so Q5 only observes. Restarting again here would wipe the
-        // map entry this ordering exists to preserve.
         val restartDetail = when {
             attemptTethering -> "downstream restarted before TUN creation"
             else -> "no restart: observing the running downstream"
@@ -378,10 +283,6 @@ class ProbeRunner(private val context: Context) {
         probeIpv6Surface(report)
     }
 
-    /**
-     * Q5 is the actual viability answer: does the tethering stack select our
-     * TUN? Polls what the stack reports until it settles or the deadline passes.
-     */
     private fun observeUpstream(
         report: ProbeReportBuilder,
         interfaceName: String,
@@ -411,23 +312,12 @@ class ProbeRunner(private val context: Context) {
         )
     }
 
-    /**
-     * The raw dump opens with several KB of static tetherable-regex and DHCP
-     * config, so a leading excerpt spent its budget before reaching anything
-     * decision-relevant.
-     */
     private fun selectionLines(rawOutput: String): String =
         rawOutput.lineSequence()
             .filter { line -> SELECTION_KEYS.any { key -> line.contains(key) } }
             .joinToString("\n")
             .take(DUMP_EXCERPT_CHARS)
 
-    /**
-     * Reselection is asynchronous — setPreferTestNetworks(true) does not move
-     * an already-chosen upstream, and the first device run read wlan0
-     * microseconds after setting it. Returns the last observation on timeout so
-     * the failure detail stays honest.
-     */
     private fun awaitUpstreamSettle(interfaceName: String): UpstreamObservation {
         val deadline = System.currentTimeMillis() + UPSTREAM_SETTLE_MS
         var latest = inspector.observe()
@@ -444,11 +334,6 @@ class ProbeRunner(private val context: Context) {
         return latest
     }
 
-    /**
-     * Q6: can IPv6 be suppressed on the downstream? R6.4 needs it blocked or
-     * unadvertised and L-7 is unpassable otherwise, so this reports the current
-     * forwarding and RA state before Phase 6 depends on it.
-     */
     private fun probeIpv6Surface(report: ProbeReportBuilder) {
         val forwarding = readProcValue(IPV6_FORWARDING_PATH)
         val acceptRa = readProcValue(IPV6_ACCEPT_RA_PATH)
@@ -467,15 +352,6 @@ class ProbeRunner(private val context: Context) {
     private fun readProcValue(path: String): String? =
         runCatching { java.io.File(path).readText().trim() }.getOrNull()
 
-    /**
-     * Normally a no-op — [run] releases in its own finally — but kept so
-     * TetherService.stop can guarantee a diagnostic's resources cannot outlive
-     * an unrelated session teardown.
-     *
-     * Fail-closed order as in [releaseSession]: the caller has already stopped
-     * the session's downstream (R6.1), and this hands the upstream back before
-     * destroying the TUN.
-     */
     fun teardown(): String {
         val downstreamProblem = when {
             didStartDownstream -> teardown.releaseDownstream()
@@ -521,7 +397,7 @@ class ProbeRunner(private val context: Context) {
         put("sdkInt", Build.VERSION.SDK_INT)
         put("release", Build.VERSION.RELEASE)
         put("uid", Process.myUid())
-        // Must match the UID's package or framework services reject the calls.
+
         put("contextPackage", context.packageName)
     }
 
@@ -529,24 +405,16 @@ class ProbeRunner(private val context: Context) {
         const val SHELL_UID = 2000
         const val ROOT_UID = 0
 
-        /** TEST-NET-1 per spec R3.2. */
         const val TUN_ADDRESS = "192.0.2.2"
         const val TUN_PREFIX_LENGTH = 24
 
-        /** The IPv6 counterpart, from the documentation range so it cannot collide. */
         const val TUN_ADDRESS_V6 = "2001:db8::2"
         const val TUN_PREFIX_LENGTH_V6 = 64
 
-
-        /**
-         * Link MTU for the TUN (R5.5 default). Egress is direct rather than
-         * tunnelled, so there is no encapsulation overhead to subtract yet.
-         */
         const val TUN_MTU = 1500
 
         const val DUMP_EXCERPT_CHARS = 4000
 
-        /** dumpsys tethering substrings that bear on which upstream is chosen. */
         val SELECTION_KEYS = listOf(
             "Current upstream",
             "Upstream wanted",
@@ -557,13 +425,6 @@ class ProbeRunner(private val context: Context) {
             "testtun",
         )
 
-        /**
-         * How long Q5 waits for upstream selection to settle (R4.4 fixes no
-         * duration). Selection that works takes ~100ms and the loop returns
-         * immediately, so this is only ever paid in full on failure — a longer
-         * deadline just made failing runs slow to say what the first second
-         * already showed.
-         */
         const val UPSTREAM_SETTLE_MS = 8_000L
         const val UPSTREAM_POLL_MS = 1_000L
         const val TAG = "ProbeRunner"
@@ -580,7 +441,6 @@ class ProbeRunner(private val context: Context) {
             "Does a NetworkCallback listen ever deliver the test network? " +
                 "(this is what populates UpstreamNetworkMonitor.mNetworkMap)"
 
-        /** Selection happens in ~100ms when it works; 5s is generous. */
         const val CALLBACK_WAIT_MS = 5_000L
     }
 }

--- a/app/src/main/java/dev/shizzi/SessionLog.kt
+++ b/app/src/main/java/dev/shizzi/SessionLog.kt
@@ -7,7 +7,6 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-/** Rendered, not filtered — the log shows everything. */
 enum class LogLevel { INFO, WARN, ERROR }
 
 data class LogEntry(
@@ -16,47 +15,25 @@ data class LogEntry(
     val message: String,
 )
 
-/**
- * The session log, written from two processes into two files.
- *
- * The events worth reading happen in the shell process, and the app cannot read
- * logcat without a permission it does not hold — so the shell writes to a file.
- * It has to be two files: /data/local/tmp is shell-owned mode 0771, so the app
- * can read what the shell creates there but cannot write it at all.
- *
- * Both processes share a clock, so sorting [merged] by timestamp restores the
- * true order.
- */
 object SessionLog {
 
     private const val TAG = "SessionLog"
 
-    /** Written by the shell process, world-readable so the app can read it. */
     const val SHELL_PATH = "/data/local/tmp/shizzi.log"
 
-    /**
-     * Cap and reclaim target, per file. Keeps the newest half rather than
-     * emptying, which would discard exactly what a user reads after a failure.
-     */
     private const val MAX_BYTES = 1_000_000L
     private const val KEEP_BYTES = 500_000L
 
     private val TIMESTAMP = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
 
-    /** Splits "<timestamp> <LEVEL> <message>" without splitting the message. */
     private val LINE = Regex("""^(\S+ \S+)\s+(INFO|WARN|ERROR)\s+(.*)$""")
 
-    /** The shell leaves this at the world-readable path only it can create. */
     @Volatile
     private var writePath: String = SHELL_PATH
 
     @Volatile
     private var readPaths: List<String> = listOf(SHELL_PATH)
 
-    /**
-     * Gates [append] only. Reading stays unconditional — turning logging off
-     * should stop new entries, not hide the ones already written.
-     */
     @Volatile
     private var isEnabled: Boolean = true
 
@@ -64,10 +41,6 @@ object SessionLog {
         isEnabled = enabled
     }
 
-    /**
-     * Points the app process's writes at its own storage. Called once from
-     * Application.onCreate; without it the app logs nothing, silently.
-     */
     fun useAppStorage(directory: File) {
         val appPath = File(directory, "session.log").absolutePath
         writePath = appPath
@@ -78,14 +51,6 @@ object SessionLog {
     fun warn(message: String) = append(LogLevel.WARN, message)
     fun error(message: String) = append(LogLevel.ERROR, message)
 
-    /**
-     * Mirrors to logcat before the enabled check: that channel is the
-     * developer's and costs the user nothing, while the setting governs what
-     * lands on their device.
-     *
-     * Never throws — a failed write must not take down a teardown, which is
-     * the most important thing this records.
-     */
     @Synchronized
     fun append(level: LogLevel, message: String) {
         Log.println(priorityOf(level), TAG, message)
@@ -98,8 +63,6 @@ object SessionLog {
 
             file.appendText("$stamp ${level.name.padEnd(5)} $message\n")
 
-            // The app reads the shell's file. Relying on the spawning
-            // process's umask would make that an accident.
             if (isNew) file.setReadable(true, false)
 
             truncateIfLarge(writePath)
@@ -108,24 +71,10 @@ object SessionLog {
         }
     }
 
-    /**
-     * Both files interleaved, newest first. Sorting the raw string works
-     * because the format is fixed-width; unparseable lines carry an empty
-     * timestamp and sort to the end rather than being dropped.
-     */
     fun merged(): List<LogEntry> = readPaths
         .flatMap(::readFile)
         .sortedByDescending { it.timestamp }
 
-    /**
-     * Empties every file this process can write; the other half is
-     * [ITetherService.clearLog]'s job.
-     *
-     * Truncates rather than deletes so the shell's file keeps the readable bit
-     * the app depends on — recreating it would only restore that if the next
-     * append came from the shell. Failures are logged, not raised: the caller
-     * cannot act on them, and the half that could be cleared was.
-     */
     fun clear() {
         readPaths.forEach { path ->
             runCatching { File(path).takeIf { it.exists() }?.writeText("") }
@@ -136,16 +85,11 @@ object SessionLog {
     private fun readFile(path: String): List<LogEntry> = runCatching {
         File(path).takeIf { it.exists() }?.readLines()?.mapNotNull(::parse).orEmpty()
     }.getOrElse { failure ->
-        // Normal before the first session, so not surfaced as an error entry.
+
         Log.w(TAG, "read $path: ${failure.message}")
         emptyList()
     }
 
-    /**
-     * Keeps unparseable lines: a stack-trace continuation or a line from an
-     * older format is still evidence, and often the unusual output worth
-     * seeing.
-     */
     private fun parse(line: String): LogEntry? {
         if (line.isBlank()) return null
 
@@ -156,10 +100,6 @@ object SessionLog {
         return LogEntry(timestamp, LogLevel.valueOf(level), message)
     }
 
-    /**
-     * Drops the oldest half once a file passes the cap. Reads only the tail —
-     * this runs on the thread that just logged.
-     */
     private fun truncateIfLarge(path: String) {
         val file = File(path)
         if (file.length() <= MAX_BYTES) return
@@ -167,7 +107,6 @@ object SessionLog {
         val kept = RandomAccessFile(file, "r").use { reader ->
             reader.seek(file.length() - KEEP_BYTES)
 
-            // The seek lands mid-line; discard the partial one.
             reader.readLine()
 
             val remaining = ByteArray((reader.length() - reader.filePointer).toInt())

--- a/app/src/main/java/dev/shizzi/SessionNotification.kt
+++ b/app/src/main/java/dev/shizzi/SessionNotification.kt
@@ -8,13 +8,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 
-/**
- * The notification a running session posts, split from SessionService so the
- * wording is not interleaved with the concurrency.
- *
- * The register throughout is the user's — a hotspot they are sharing, not a
- * tunnel or an interface name. Those live in the log.
- */
 class SessionNotification(private val context: Context) {
 
     fun build(state: SessionUiState, isStopping: Boolean): Notification {
@@ -33,16 +26,6 @@ class SessionNotification(private val context: Context) {
             .build()
     }
 
-    /**
-     * [isStopping] disambiguates LOADING, which covers both directions.
-     *
-     * Never says "protected": with no VPN up, traffic leaves over the physical
-     * network exactly as ordinary tethering would, so the word claimed a
-     * security property the app does not deliver.
-     *
-     * ERROR and READY share a title — the session is over either way, and the
-     * body carries which.
-     */
     private fun titleFor(state: SessionUiState, isStopping: Boolean): String =
         when (state.status) {
             UiStatus.CONNECTED -> connectedTitle(state.isVpnBound)
@@ -51,24 +34,11 @@ class SessionNotification(private val context: Context) {
             UiStatus.READY -> "Session ended"
         }
 
-    /**
-     * In the title, where a collapsed notification shows it. Its absence goes
-     * unstated — announcing what is *not* happening spends the one line
-     * available on a non-event.
-     */
     private fun connectedTitle(isVpnBound: Boolean): String = when {
         isVpnBound -> "Connected · VPN"
         else -> "Connected"
     }
 
-    /**
-     * An error outranks everything: it is the only text here a user may need to
-     * act on.
-     *
-     * Nothing reaches this that was not written to be read. The old fallthrough
-     * handed [SessionUiState.detail] over verbatim and put "tethered clients
-     * routing through testtun47" — or a raw exception name — on a notification.
-     */
     private fun bodyFor(state: SessionUiState, isStopping: Boolean): String = when {
         state.lastError.isNotEmpty() -> userFacingError(state.lastError)
         state.status == UiStatus.LOADING -> loadingBody(isStopping)
@@ -76,11 +46,6 @@ class SessionNotification(private val context: Context) {
         else -> "Not sharing"
     }
 
-    /**
-     * @return [raw] when it was written for a user, else a plain stand-in. A
-     *   stack-trace fragment reads as a crash and offers nothing to act on; it
-     *   survives in the log either way.
-     */
     private fun userFacingError(raw: String): String = when {
         raw.contains(EXCEPTION_MARKER) -> "Something went wrong. Check the app for details."
         else -> raw
@@ -89,14 +54,6 @@ class SessionNotification(private val context: Context) {
     private fun loadingBody(isStopping: Boolean): String =
         if (isStopping) "Turning the hotspot off…" else "Turning the hotspot on…"
 
-    /**
-     * How many devices and how much has moved — the only thing on the
-     * notification that changes while a session runs.
-     *
-     * "0 devices · ↓ 0 B" reads as a fault rather than an empty hotspot, so
-     * that case is stated plainly. No terminal periods: these are fragments,
-     * unlike the full sentences below that tell a user what to do.
-     */
     private fun connectedBody(state: SessionUiState): String = when (state.clientCount) {
         0 -> "No devices connected"
         else -> "${deviceCount(state.clientCount)} · " +
@@ -109,7 +66,6 @@ class SessionNotification(private val context: Context) {
         else -> "$clients devices"
     }
 
-    /** Phrased as what happened and what to do, not as a return value. */
     fun describeLoss(problem: String?): String = when (problem) {
         null -> "Shizuku stopped, so the session ended. The hotspot was turned off. " +
             "Start again when you are ready."
@@ -154,14 +110,8 @@ class SessionNotification(private val context: Context) {
     private companion object {
         const val CHANNEL_ID = "tethering-session"
 
-        /** How a Kotlin exception name reads once it reaches a UI string. */
         const val EXCEPTION_MARKER = "Exception"
 
-        /**
-         * U+2193/U+2191 render in the notification's text font at the weight of
-         * the digits beside them; the emoji variants come from the colour font
-         * and sit as blobs against monochrome text.
-         */
         const val DOWN_ARROW = "\u2193"
         const val UP_ARROW = "\u2191"
     }

--- a/app/src/main/java/dev/shizzi/SessionResources.kt
+++ b/app/src/main/java/dev/shizzi/SessionResources.kt
@@ -8,13 +8,6 @@ import android.os.ParcelFileDescriptor
 import datapath.Datapath
 import datapath.Session as DatapathSession
 
-/**
- * The atomic resource group of R3.5: TUN fd, framework interface, network
- * handle, and callback registration, acquired and released together.
- *
- * Nothing outside this class holds any of the four — T-2 (orphaned testtun,
- * leaked fd) is what happens when those lifetimes drift apart.
- */
 class SessionResources(
     private val testNetworkApi: TestNetworkApi,
     private val connectivityManager: ConnectivityManager,
@@ -26,19 +19,11 @@ class SessionResources(
     private var datapathSession: DatapathSession? = null
     private var keepAliveCallback: ConnectivityManager.NetworkCallback? = null
 
-    /** Binder whose lifetime the framework ties the test network to. */
     private val lifetimeToken = Binder()
 
     val interfaceName: String? get() = runCatching { tun?.interfaceName }.getOrNull()
     val acquiredNetwork: Network? get() = network
 
-    /**
-     * Creates the TUN, registers it as a test network, and blocks until
-     * ConnectivityManager reports it available.
-     *
-     * @throws IllegalStateException naming the failing operation. Callers must
-     *   [release] on failure; partial state is never implicitly owned.
-     */
     fun acquire(
         addresses: List<android.net.LinkAddress>,
         dnsServers: List<java.net.InetAddress>,
@@ -56,15 +41,6 @@ class SessionResources(
         return name
     }
 
-    /**
-     * Tethering consuming a network as its upstream is not a NetworkRequest, so
-     * with nothing requesting it ConnectivityService lingers the test network
-     * the moment it connects — "handleLingerComplete for [N TEST]" about four
-     * seconds after start, with the upstream reverting to cellular.
-     *
-     * requestNetwork, not registerNetworkCallback: only a request holds a
-     * network; a listen callback observes it.
-     */
     private fun requestKeepAlive() {
         val request = NetworkRequest.Builder()
             .clearCapabilities()
@@ -85,14 +61,6 @@ class SessionResources(
             }
     }
 
-    /**
-     * Nothing in the kernel forwards packets out of a test network's TUN, so
-     * without this tethered clients get a DHCP lease and no connectivity. The
-     * datapath joins the same atomic group as the fd it reads.
-     *
-     * @throws IllegalStateException naming the fd, so this is distinguishable
-     *   from a TUN or test-network failure.
-     */
     fun startDatapath(mtu: Int) {
         val descriptor = fileDescriptor
             ?: error("startDatapath: no TUN fd; acquire() must succeed first")
@@ -107,12 +75,6 @@ class SessionResources(
             }
     }
 
-    /**
-     * Pins the datapath's upstream sockets to [handle], or unbinds at 0.
-     *
-     * @throws IllegalStateException when acquire and startDatapath have not
-     *   both succeeded.
-     */
     fun bindDatapathTo(handle: Long) {
         val session = datapathSession
             ?: error("bindDatapathTo($handle): no datapath session; startDatapath must succeed first")
@@ -120,11 +82,6 @@ class SessionResources(
         session.setNetwork(handle)
     }
 
-    /**
-     * R3.3 makes the timeout a hard failure: returning without a Network lets
-     * tethering start against an upstream that does not exist yet — the R4.3
-     * race.
-     */
     private fun awaitAvailability(interfaceName: String, timeoutMs: Int): Network {
         val deadline = System.currentTimeMillis() + timeoutMs
 
@@ -135,33 +92,20 @@ class SessionResources(
         error("test network '$interfaceName' did not become available within ${timeoutMs}ms")
     }
 
-    /**
-     * Polling rather than registerNetworkCallback, which from the shell UID is
-     * rejected with "Package android does not belong to 2000" even with the
-     * context rebased. getAllNetworks/getLinkProperties carry no such check.
-     */
     private fun findNetworkOn(interfaceName: String): Network? =
         connectivityManager.allNetworks.firstOrNull { candidate ->
             connectivityManager.getLinkProperties(candidate)?.interfaceName == interfaceName
         }
 
-    /**
-     * Continues past individual failures — a failed teardownTestNetwork must
-     * not prevent closing the fd — and returns them rather than swallowing them.
-     */
     fun release(): List<String> {
         val problems = mutableListOf<String>()
 
-        // First, so the framework lingers the network normally rather than
-        // racing our explicit teardown.
         keepAliveCallback?.let { callback ->
             runCatching { connectivityManager.unregisterNetworkCallback(callback) }
                 .onFailure { problems += "unregisterNetworkCallback: ${it.message}" }
         }
         keepAliveCallback = null
 
-        // Before the fd: the stack is actively reading it, and closing it first
-        // leaves reads racing against a descriptor the kernel may have reused.
         datapathSession?.let { session ->
             runCatching { session.stop() }
                 .onFailure { problems += "datapath.stop: ${it.message}" }
@@ -181,8 +125,6 @@ class SessionResources(
         fileDescriptor = null
         tun = null
 
-        // To the session log, not only logcat: a leak here is what the next
-        // start trips over, and the log is where that gets diagnosed.
         problems.forEach { SessionLog.warn("teardown problem: $it") }
         return problems
     }

--- a/app/src/main/java/dev/shizzi/SessionService.kt
+++ b/app/src/main/java/dev/shizzi/SessionService.kt
@@ -23,17 +23,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-/**
- * Keeps the app process alive for as long as a session is up.
- *
- * The privileged work happens in the shell process; what this owns is the
- * *watching* of it. The death recipient that drops an orphaned hotspot lives
- * here, and a cached process can be reclaimed at any moment along with it — the
- * shell dying leaves the hotspot tethered with clients on cellular.
- *
- * Hence a service and not a ViewModel: an Activity's lifetime ends when the
- * user swipes the app away, exactly when the leak would go unnoticed.
- */
 class SessionService : Service() {
 
     private val scope = CoroutineScope(SupervisorJob())
@@ -41,36 +30,14 @@ class SessionService : Service() {
     private val notification by lazy { SessionNotification(this) }
     private val statusPoller = SessionStatusPoller(scope, controller)
 
-    /** The companion's flow, so the UI sees updates from before onCreate ran. */
     private val internalState get() = sessionState
 
-    /**
-     * LOADING covers both directions, so without this the notification reads
-     * "Starting…" throughout a teardown — the opposite of what is happening.
-     */
     private var isStopping = false
 
-    /**
-     * The in-flight start, so a stop can interrupt it. Cancelling without
-     * awaiting lets the two interleave: the downstream was confirmed down at
-     * 22:34:06 and the start brought a *new* TUN up at 22:34:07.
-     */
     private var startJob: Job? = null
 
-    /**
-     * Counts intents, so a superseded one cannot publish state. A cancelled
-     * start is still inside a blocking binder call and returns after the user
-     * has been shown an idle screen; folding that in flips them back to an
-     * error they cancelled their way out of.
-     */
     private var generation = 0
 
-    /**
-     * Serialises privileged work. Cancelling idles the screen and drains the
-     * teardown behind it, so the user can press Start while the old teardown
-     * runs — which would otherwise sweep away the TUN of the session they are
-     * waiting on.
-     */
     private val sessionLock = Mutex()
 
     override fun onCreate() {
@@ -79,11 +46,6 @@ class SessionService : Service() {
         liveService = this
     }
 
-    /**
-     * Foregrounds before anything else: Android kills a service that has not
-     * posted its notification within a few seconds, and both paths below run
-     * longer than that.
-     */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         isStopping = intent?.action == ACTION_STOP
         startForeground(
@@ -101,7 +63,6 @@ class SessionService : Service() {
         return START_NOT_STICKY
     }
 
-    /** Not a bound service: the UI observes [liveState] instead. */
     override fun onBind(intent: Intent?): IBinder? = null
 
     private fun startSession() {
@@ -112,23 +73,15 @@ class SessionService : Service() {
         }
 
         startJob = scope.launch {
-            // From the store, not UI state: the notification can start this
-            // with no screen alive to have populated it.
+
             val isLogging = settingsStore().settings.first().isLogging
 
-            // Waits out a teardown still draining, which would otherwise sweep
-            // away what this start is about to build.
             val outcome = sessionLock.withLock {
                 if (attempt != generation) return@launch
                 runCatching { controller.start(isLogging) }
             }
             if (attempt != generation) return@launch
 
-            // The shell process logs its own start failures. This covers the
-            // ones it never hears about -- a bind that never completed, a
-            // contract check that rejected the daemon -- which otherwise
-            // appeared on screen and nowhere else, leaving the log a user sends
-            // in with no record of the failure they are reporting.
             outcome.exceptionOrNull()?.let { failure ->
                 SessionLog.error(
                     "start failed in the app process: " +
@@ -153,23 +106,9 @@ class SessionService : Service() {
     private fun settingsStore(): SettingsStore =
         (application as App).settingsStore
 
-    /**
-     * The screen goes idle immediately, not when teardown returns: stopping is
-     * not a request that can be refused, so a spinner would only make the user
-     * watch a decision already made. Teardown drains behind it.
-     *
-     * Bumping the generation first is what makes that safe against the late
-     * result of an in-flight start. stopSelf waits for teardown — dropping the
-     * foreground state early lets the process be reclaimed mid-teardown, the
-     * leak this service exists to prevent.
-     */
     private fun stopSession() {
         val stopped = ++generation
 
-        // Captured here, not inside the coroutine, which would read whatever
-        // start is current *then*: a Start/Cancel/Start burst had the cancel's
-        // teardown join the second start and tear down what the user just asked
-        // for.
         val abandoned = startJob
         startJob = null
 
@@ -178,47 +117,27 @@ class SessionService : Service() {
         internalState.update {
             it.asStopped()
         }
-        // Otherwise the notification holds onStartCommand's text for the whole
-        // teardown, which outlasts a cancelAndJoin plus a privileged release.
+
         publishState()
 
         scope.launch {
-            // Wait for the abandoned start to actually leave: tearing down
-            // alongside one lets it create a TUN after the sweep.
+
             abandoned?.cancelAndJoin()
 
-            // Logged rather than rendered — the screen is already idle, and a
-            // toast here would contradict the state the user asked for.
             sessionLock.withLock {
                 runCatching { controller.stop() }
                     .onFailure { SessionLog.error("teardown failed: ${it.message}") }
 
-                // The daemon holds the TUN's fd, so terminating it is what
-                // actually destroys the interface.
-                //
-                // Unconditional, and safe because a start binds inside this
-                // same lock: anything newer waits here and binds a fresh daemon
-                // after. Skipping this when a newer request had arrived left an
-                // orphan per stop-then-start, each holding a TUN that tethering
-                // could later select and fail the next session against.
                 controller.unbindAndStopDaemon()
             }
 
-            // A start that arrived mid-teardown is the current generation, and
-            // stopping the service would kill it.
             if (stopped == generation) stopSelf()
         }
     }
 
-    /**
-     * Drops the hotspot left by a dead shell process — without it the hotspot
-     * stays up and tethering reverts to cellular with clients attached.
-     * Arrives on a binder thread.
-     */
     private fun handleSessionLost() {
         statusPoller.stop()
 
-        // Not a user-initiated stop; the ERROR title applies, not "Stopping…".
         isStopping = false
         SessionLog.error("shell process died; recovering any downstream it left up")
 
@@ -247,7 +166,6 @@ class SessionService : Service() {
         }
     }
 
-    /** Mirrors the current state into the notification. */
     private fun publishState() {
         notificationManager().notify(
             NOTIFICATION_ID,
@@ -270,19 +188,12 @@ class SessionService : Service() {
         private const val NOTIFICATION_ID = 1
         const val ACTION_STOP = "dev.shizzi.STOP_SESSION"
 
-        /**
-         * Exists whether or not a service is running: the UI subscribes the
-         * instant Start is pressed, while startForegroundService is still
-         * asynchronous. A flow that appeared with the service left the screen
-         * subscribed to nothing and stuck on LOADING through an ACTIVE session.
-         */
         private val sessionState = MutableStateFlow(SessionUiState())
 
         val liveState: StateFlow<SessionUiState> = sessionState.asStateFlow()
 
         private var liveService: SessionService? = null
 
-        /** Whether a session is currently running. */
         val isRunning: Boolean get() = liveService != null
 
         fun start(context: Context) {

--- a/app/src/main/java/dev/shizzi/SessionStatusPoller.kt
+++ b/app/src/main/java/dev/shizzi/SessionStatusPoller.kt
@@ -5,15 +5,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-/**
- * Mirrors the shell process's view of a live session into the app's, because
- * the privileged side has no way to push: it can adopt or lose a VPN long after
- * start returned, and the badge and notification would render whatever the last
- * binder call reported.
- *
- * Runs only while connected — status() binds if nothing is bound, so a poller
- * left running past teardown resurrects the process the user just stopped.
- */
 class SessionStatusPoller(
     private val scope: CoroutineScope,
     private val controller: TetherClient,
@@ -21,11 +12,6 @@ class SessionStatusPoller(
 
     private var job: Job? = null
 
-    /**
-     * @param onStatus called only for a successful read: a failed one is not a
-     *   failed session — the shell's own watchdogs decide that — and an error
-     *   here would contradict a session still running fine.
-     */
     fun follow(isConnected: () -> Boolean, onStatus: (Result<String>) -> Unit) {
         stop()
         if (!isConnected()) return
@@ -47,12 +33,7 @@ class SessionStatusPoller(
     }
 
     private companion object {
-        /**
-         * Fast enough that the byte counters read as live rather than stepped.
-         * Affordable only because a status read no longer spawns a process —
-         * at the old ~127ms per read this would have burned ~13% of a core for
-         * the life of every session.
-         */
+
         const val POLL_INTERVAL_MS = 1_000L
     }
 }

--- a/app/src/main/java/dev/shizzi/SessionTeardown.kt
+++ b/app/src/main/java/dev/shizzi/SessionTeardown.kt
@@ -2,25 +2,11 @@ package dev.shizzi
 
 import android.content.Context
 
-/**
- * The ordering-sensitive release of what the framework owns — upstream
- * selection, downstream, and the shutdown hook for an abrupt exit. Split from
- * TetherSession so that class stays about the lifecycle it runs.
- */
 class SessionTeardown(private val context: Context) {
 
     private val inspector = UpstreamInspector()
     private var shutdownHook: Thread? = null
 
-    /**
-     * Covers exactly one path: ShizukuServiceStarter calling System.exit when
-     * its server goes away, which is how the 13.5.4 crash took this process
-     * down.
-     *
-     * ART does not unwind hooks on signal death, so SIGTERM and SIGKILL bypass
-     * this — a device test left the hotspot tethered with no hook output.
-     * Recovery for those lives in the app process, which outlives this one.
-     */
     fun installShutdownHook() {
         val hook = Thread {
             SessionLog.warn("process exiting with session active; dropping downstream")
@@ -34,29 +20,12 @@ class SessionTeardown(private val context: Context) {
 
     fun removeShutdownHook() {
         shutdownHook?.let { hook ->
-            // Throws if the JVM is already shutting down, which is exactly when
-            // the hook should stay installed.
+
             runCatching { Runtime.getRuntime().removeShutdownHook(hook) }
         }
         shutdownHook = null
     }
 
-    /**
-     * Hands the upstream back *before* the TUN is destroyed. This ordering is
-     * load-bearing: tethering's own teardown needs the interface to exist, so
-     * destroying it first leaves the framework logging
-     *
-     *     [BpfCoordinator] Could not detach program: Fail to get interface
-     *     params for interface testtunNN
-     *
-     * and still naming that dead interface as the upstream. Every later start
-     * then fails verifyUpstream against a ghost — permanently, unclearable
-     * short of a reboot. A device test wedged a phone this way for eleven
-     * consecutive sessions.
-     *
-     * The wait is bounded and best effort: past the deadline, destroying the
-     * interface still beats leaking it.
-     */
     fun releaseUpstreamSelection(interfaceName: String?) {
         val cleared = runCatching { TetheringPreferenceApi(context).setPreferTestNetworks(false) }
             .onFailure {
@@ -82,7 +51,6 @@ class SessionTeardown(private val context: Context) {
         SessionLog.warn("upstream still reads $name after ${UPSTREAM_RELEASE_MS}ms; releasing anyway")
     }
 
-    /** @return null once no downstream is tethered, else what is still up. */
     fun releaseDownstream(): String? {
         val control = DownstreamControl(context)
 
@@ -105,10 +73,6 @@ class SessionTeardown(private val context: Context) {
     private companion object {
         const val UPSTREAM_POLL_MS = 500L
 
-        /**
-         * Shorter than the settle deadline: letting go of an interface is not
-         * selecting and validating a new one, and the session is on its way out.
-         */
         const val UPSTREAM_RELEASE_MS = 4_000L
     }
 }

--- a/app/src/main/java/dev/shizzi/SessionViewModel.kt
+++ b/app/src/main/java/dev/shizzi/SessionViewModel.kt
@@ -15,25 +15,12 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-/**
- * Renders whatever the session service is doing, and asks it to start or stop.
- *
- * Holds no session: a ViewModel dies when the user swipes the app away, taking
- * the death recipient that drops an orphaned hotspot with it, so the session
- * belongs to [SessionService].
- */
 class SessionViewModel(application: Application) : AndroidViewModel(application) {
 
-    /** Owned here because diagnostics are a UI action, not part of a session. */
     private val diagnostics = TetherClient()
 
     private val settingsStore = getApplication<App>().settingsStore
 
-    /**
-     * Null rather than a default until the first read lands: rendering under
-     * SYSTEM while the stored choice loads flashes the wrong theme, so the
-     * activity holds the frame until this is non-null.
-     */
     val settings: StateFlow<Settings?> = settingsStore.settings.stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,
@@ -49,7 +36,6 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
     private val localCompatibility = MutableStateFlow<CompatibilityState>(CompatibilityState.Idle)
     val compatibilityState: StateFlow<CompatibilityState> = localCompatibility.asStateFlow()
 
-    /** Guards against a second collector per onResume. */
     private var sessionCollector: Job? = null
 
     init {
@@ -57,11 +43,6 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         observeSession()
     }
 
-    /**
-     * With no service running the local state stands alone and renders as idle.
-     * Shizuku availability is tracked here either way — it gates the button
-     * before any session exists.
-     */
     private fun observeSession() {
         if (sessionCollector?.isActive == true) return
 
@@ -80,10 +61,6 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         ShizukuGate.requestPermission()
     }
 
-    /**
-     * Both processes, because a running session writes most of its entries from
-     * the shell — persisting alone leaves the toggle inert until the next start.
-     */
     fun setLogging(enabled: Boolean) {
         SessionLog.setEnabled(enabled)
         diagnostics.setLogging(enabled)
@@ -94,7 +71,6 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         viewModelScope.launch { settingsStore.setTheme(choice) }
     }
 
-    /** One button: starts when idle, stops when connected. */
     fun toggle() {
         val context = getApplication<Application>()
 
@@ -104,14 +80,6 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    /**
-     * Routed to stop, not toggle: a cancel arrives while the status is LOADING,
-     * which toggle would read as idle and answer with a second session. The
-     * same teardown dismantles a half-built session and a whole one.
-     *
-     * Resets the screen here rather than awaiting the service — cancelling
-     * cannot fail, so waiting would only show the app thinking about it.
-     */
     fun cancel() {
         localState.update {
             it.asStopped()
@@ -119,15 +87,6 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         SessionService.stop(getApplication())
     }
 
-    /**
-     * Direct rather than through the service: diagnostics tear down what they
-     * create and hold no session for it to outlive.
-     *
-     * The result lands in [diagnosticsState], not session state. Folding it
-     * through applyOutcome — which reads a *session status* — parsed a report
-     * carrying no "state" field as a session gone READY, resetting the home
-     * screen's status, interface, and counters while discarding the report.
-     */
     fun runProbes() {
         if (localDiagnostics.value is DiagnosticsState.Running) return
         localDiagnostics.value = DiagnosticsState.Running
@@ -139,9 +98,7 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
                         DiagnosticsState.Complete(report, TetherService.REPORT_PATH)
                     },
                     onFailure = { failure ->
-                        // Same reason as the service's start path: a run that
-                        // never reached the shell process publishes no report,
-                        // so without this the failure is on screen only.
+
                         SessionLog.error(
                             "diagnostics failed in the app process: " +
                                 "${failure.javaClass.name}: ${failure.message}",
@@ -155,13 +112,6 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    /**
-     * Resolves the two APIs the app rests on, through the shell.
-     *
-     * A thrown failure is [CompatibilityState.Failed] rather than a verdict of
-     * incompatible: not reaching Shizuku says nothing about the device, and
-     * telling a working handset it is unsupported is the worse error.
-     */
     fun checkCompatibility() {
         if (localCompatibility.value is CompatibilityState.Checking) return
         localCompatibility.value = CompatibilityState.Checking
@@ -179,39 +129,20 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    /** Persisted, so the wizard is a first run rather than a launch screen. */
     fun completeOnboarding() {
         viewModelScope.launch { settingsStore.setOnboardingComplete(true) }
     }
 
-    /**
-     * Sends the app back to the wizard.
-     *
-     * The compatibility result is dropped with it: the step re-runs its check
-     * on arrival, and keeping the old verdict would show a stale COMPATIBLE
-     * badge for the moment before the new run reports.
-     */
     fun restartOnboarding() {
         localCompatibility.value = CompatibilityState.Idle
         viewModelScope.launch { settingsStore.setOnboardingComplete(false) }
     }
 
-    /** Drops a finished run's result, so its toast leaves the screen. */
     fun dismissDiagnostics() {
         if (localDiagnostics.value is DiagnosticsState.Running) return
         localDiagnostics.value = DiagnosticsState.Idle
     }
 
-    /**
-     * Empties both halves, since neither process can write the other's. The
-     * shell half is attempted even unbound, at the cost of a bind: that file
-     * holds most of the history, and skipping it shows a "cleared" log with
-     * entries still in it.
-     *
-     * @param onCleared runs on the main thread with null on success, else why
-     *   the shell's half survived. The screen needs it to reload — the list is
-     *   read once per visit.
-     */
     fun clearLog(onCleared: (String?) -> Unit) {
         viewModelScope.launch {
             withContext(Dispatchers.IO) { SessionLog.clear() }
@@ -220,8 +151,7 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
     }
 
     override fun onCleared() {
-        // Only the diagnostics binding: unbinding the session's would drop the
-        // death recipient that the service exists to keep registered.
+
         diagnostics.unbind()
         super.onCleared()
     }

--- a/app/src/main/java/dev/shizzi/SessionWatchdog.kt
+++ b/app/src/main/java/dev/shizzi/SessionWatchdog.kt
@@ -3,17 +3,6 @@ package dev.shizzi
 import android.util.Log
 import java.util.concurrent.atomic.AtomicBoolean
 
-/**
- * Tears the session down when the tunnel stops being the sole upstream.
- *
- * verifyUpstream covers only the first seconds after start, but tethering can
- * reselect later — a cell handover, the retry timer, a Wi-Fi change — and
- * nothing else notices the session reporting ACTIVE while clients have moved
- * onto the physical upstream. That silent fallback is why the response is to
- * stop rather than repair.
- *
- * Runs in the shell process beside the session, so it dies when the session does.
- */
 class SessionWatchdog(
     private val expectedInterface: String,
     private val onDrift: (String) -> Unit,
@@ -23,11 +12,6 @@ class SessionWatchdog(
     private val isRunning = AtomicBoolean(false)
     private var thread: Thread? = null
 
-    /**
-     * A single dumpsys miss is not evidence: parsing is loose and the upstream
-     * is briefly empty during normal reselection, so acting on one sample would
-     * trade a rare silent leak for frequent spurious disconnects.
-     */
     private var consecutiveFailures = 0
 
     fun start() {
@@ -39,12 +23,6 @@ class SessionWatchdog(
         }
     }
 
-    /**
-     * Safe to call from [onDrift]: interrupting from inside its own callback
-     * would flag the thread about to run teardown, and stopWifiTethering's
-     * settle would throw InterruptedException exactly when the downstream most
-     * needs to come down.
-     */
     fun stop() {
         isRunning.set(false)
 
@@ -68,16 +46,9 @@ class SessionWatchdog(
         }
     }
 
-    /**
-     * @return null while the tunnel is still the sole upstream, otherwise a
-     *   description of the drift once it has persisted long enough to trust.
-     */
     private fun checkUpstream(): String? {
         val observation = inspector.observe()
 
-        // A destroyed interface tethering still names is not traffic leaving
-        // over a physical upstream; tearing down over a ghost would be the
-        // drift response firing at nothing.
         val names = observation.liveInterfaceNames(expectedInterface)
 
         val isHealthy = !observation.didTimeout &&
@@ -109,7 +80,6 @@ class SessionWatchdog(
         const val TAG = "SessionWatchdog"
         const val POLL_INTERVAL_MS = 5_000L
 
-        /** Two strikes: tolerates a transient miss, still reacts within ~10s. */
         const val FAILURES_BEFORE_TEARDOWN = 2
     }
 }

--- a/app/src/main/java/dev/shizzi/SettingsStore.kt
+++ b/app/src/main/java/dev/shizzi/SettingsStore.kt
@@ -11,20 +11,15 @@ import dev.shizzi.ui.theme.ThemeChoice
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-/** Everything the user can configure, in one readable shape. */
 data class Settings(
     val theme: ThemeChoice = ThemeChoice.SYSTEM,
     val isLogging: Boolean = true,
-    /** False until the wizard has been seen through to its last step. */
+
     val hasCompletedOnboarding: Boolean = false,
 )
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore("settings")
 
-/**
- * Persists the two settings the app has. Logging used to live in ViewModel
- * memory and reset on every launch, which made it unreliable as a setting.
- */
 class SettingsStore(private val context: Context) {
 
     val settings: Flow<Settings> = context.dataStore.data.map(::toSettings)
@@ -37,19 +32,10 @@ class SettingsStore(private val context: Context) {
         context.dataStore.edit { it[LOGGING] = enabled }
     }
 
-    /**
-     * @param hasCompleted false replays the wizard on the next composition,
-     *   which is what the developer section's restart offers — the flow is
-     *   otherwise reachable only by clearing app data.
-     */
     suspend fun setOnboardingComplete(hasCompleted: Boolean) {
         context.dataStore.edit { it[ONBOARDED] = hasCompleted }
     }
 
-    /**
-     * An unrecognised theme falls back rather than throwing: a downgrade, or a
-     * value from a future build, should not crash the app over a preference.
-     */
     private fun toSettings(preferences: Preferences) = Settings(
         theme = runCatching { ThemeChoice.valueOf(preferences[THEME].orEmpty()) }
             .getOrDefault(ThemeChoice.SYSTEM),

--- a/app/src/main/java/dev/shizzi/ShizukuGate.kt
+++ b/app/src/main/java/dev/shizzi/ShizukuGate.kt
@@ -3,7 +3,6 @@ package dev.shizzi
 import android.content.pm.PackageManager
 import rikka.shizuku.Shizuku
 
-/** The four states R1.2 requires the UI to distinguish. */
 sealed interface ShizukuState {
     data object NotInstalled : ShizukuState
     data object NotRunning : ShizukuState
@@ -11,7 +10,6 @@ sealed interface ShizukuState {
     data class Ready(val uid: Int, val isRoot: Boolean) : ShizukuState
 }
 
-/** Never requests permission: R1.3 forbids auto-requesting on launch. */
 object ShizukuGate {
 
     const val PERMISSION_REQUEST_CODE = 4001
@@ -28,20 +26,11 @@ object ShizukuGate {
         return ShizukuState.Ready(uid = uid, isRoot = uid == ROOT_UID)
     }
 
-    /**
-     * pingBinder() reports false until the sticky binder-received callback
-     * lands, which had the UI claiming Shizuku was stopped while a probe run
-     * against it succeeded. getUid() throws only when there is truly no binder.
-     */
     private fun isBinderLive(): Boolean {
         if (Shizuku.pingBinder()) return true
         return runCatching { Shizuku.getUid() }.isSuccess
     }
 
-    /**
-     * Absent or merely stopped drives different UI guidance (P-1 vs P-2), so
-     * the package manager settles it rather than a guess.
-     */
     private fun resolveAbsentBinder(): ShizukuState = when {
         isShizukuInstalled() -> ShizukuState.NotRunning
         else -> ShizukuState.NotInstalled
@@ -59,7 +48,6 @@ object ShizukuGate {
         Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
     }.getOrDefault(false)
 
-    /** Explicit user-driven request only (R1.3). */
     fun requestPermission() {
         Shizuku.requestPermission(PERMISSION_REQUEST_CODE)
     }
@@ -70,23 +58,12 @@ object ShizukuGate {
         else -> "unexpected uid $uid"
     }
 
-    /**
-     * The same identity for a settings row, where [describeUid]'s "the path
-     * under test" would be commentary on the app rather than information.
-     */
     fun shortUid(uid: Int): String = when (uid) {
         SHELL_UID -> "2000 (shell)"
         ROOT_UID -> "0 (root)"
         else -> "$uid"
     }
 
-    /**
-     * From the package manager, not Shizuku.getVersion(), which returns the API
-     * level (13) rather than the release (13.6.0) — and the release is what
-     * matters, since 13.5.4 on Android 16 crashes within minutes.
-     *
-     * Works whether or not the service is running; no binder involved.
-     */
     fun installedVersion(): String? {
         val packageManager = App.instance.packageManager
         return SHIZUKU_PACKAGES.firstNotNullOfOrNull { candidate ->
@@ -96,6 +73,5 @@ object ShizukuGate {
         }
     }
 
-    /** Shizuku proper, and Sui's package for root-backed installs. */
     private val SHIZUKU_PACKAGES = listOf("moe.shizuku.privileged.api", "moe.shizuku.redirect")
 }

--- a/app/src/main/java/dev/shizzi/ShizziApp.kt
+++ b/app/src/main/java/dev/shizzi/ShizziApp.kt
@@ -4,33 +4,18 @@ import androidx.compose.runtime.Composable
 import dev.shizzi.ui.onboarding.OnboardingActions
 import dev.shizzi.ui.onboarding.OnboardingFlow
 
-/**
- * Everything onboarding needs that [AppActions] does not already carry.
- *
- * Separate from it because the two are used at different times by different
- * trees: [HomeScreen] never runs a compatibility check, and the wizard never
- * starts a session.
- */
 data class OnboardingEntry(
     val compatibility: CompatibilityState,
     val onCheckCompatibility: () -> Unit,
     val onComplete: () -> Unit,
 )
 
-/** What the app screens render from, which the wizard mostly does not read. */
 data class AppState(
     val session: SessionUiState,
     val settings: Settings,
     val diagnostics: DiagnosticsState,
 )
 
-/**
- * Chooses between the wizard and the app.
- *
- * Above [HomeScreen] rather than inside it: onboarding is not a destination in
- * the app's back stack — it precedes it, and a user who finishes does not
- * navigate back into it.
- */
 @Composable
 fun ShizziApp(
     state: AppState,

--- a/app/src/main/java/dev/shizzi/TetherClient.kt
+++ b/app/src/main/java/dev/shizzi/TetherClient.kt
@@ -11,10 +11,8 @@ import kotlinx.coroutines.withTimeout
 import org.json.JSONObject
 import rikka.shizuku.Shizuku
 
-/** The four states the status indicator shows. */
 enum class UiStatus { READY, LOADING, CONNECTED, ERROR }
 
-/** What the single screen renders. */
 data class SessionUiState(
     val shizukuState: ShizukuState = ShizukuState.NotRunning,
     val status: UiStatus = UiStatus.READY,
@@ -23,21 +21,15 @@ data class SessionUiState(
     val interfaceName: String = "",
     val lastError: String = "",
     val isVpnBound: Boolean = false,
-    /** How many devices are on the hotspot; 0 unless a session is up. */
+
     val clientCount: Int = 0,
-    /** Bytes carried this session, for the notification to report. */
+
     val traffic: Traffic = Traffic(),
 ) {
-    /** Shizuku must be ready before the button can do anything. */
+
     val canStart: Boolean get() = shizukuState is ShizukuState.Ready && !isBusy
 }
 
-/**
- * Defined once because both the service and the ViewModel apply it
- * optimistically the moment the user asks to stop, and a copy that forgot to
- * clear [SessionUiState.interfaceName] left "via testtunNN" under an idle
- * screen. Clients and traffic go for the same reason.
- */
 fun SessionUiState.asStopped(): SessionUiState = copy(
     isBusy = false,
     status = UiStatus.READY,
@@ -49,14 +41,6 @@ fun SessionUiState.asStopped(): SessionUiState = copy(
     traffic = Traffic(),
 )
 
-/**
- * Folds a privileged call's result into the rendered state.
- *
- * A thrown exception and a status reporting ERROR are different failures — a
- * dead binder versus the session refusing to come up — so both are surfaced.
- * Lives here rather than in a ViewModel because the session outlives any one
- * screen, so the service folds these results too.
- */
 fun SessionUiState.applyOutcome(outcome: Result<String>): SessionUiState {
     val failure = outcome.exceptionOrNull()
     if (failure != null) {
@@ -64,8 +48,7 @@ fun SessionUiState.applyOutcome(outcome: Result<String>): SessionUiState {
             isBusy = false,
             status = UiStatus.ERROR,
             lastError = "${failure.javaClass.simpleName}: ${failure.message}",
-            // A failed start tears its TUN down on the way out; a stale badge
-            // would claim a session that no longer exists is on a VPN.
+
             interfaceName = "",
             isVpnBound = false,
             clientCount = 0,
@@ -83,7 +66,7 @@ fun SessionUiState.applyOutcome(outcome: Result<String>): SessionUiState {
         detail = sessionDetail,
         interfaceName = parsed?.optString("interface").orEmpty().takeIf { it != "null" }.orEmpty(),
         lastError = if (sessionState == "ERROR") sessionDetail else "",
-        // Absent on an older shell process, which reads correctly as unbound.
+
         isVpnBound = parsed?.optBoolean("isVpnBound") == true,
         clientCount = parsed?.optInt("clientCount") ?: 0,
         traffic = Traffic(
@@ -100,22 +83,11 @@ private fun statusFor(sessionState: String): UiStatus = when (sessionState) {
     else -> UiStatus.READY
 }
 
-/**
- * Drives the privileged service from the app process.
- *
- * All calls serialize behind [isBusy] in the ViewModel (R7.6); this class holds
- * no lock of its own and assumes single-threaded entry from the UI scope.
- */
 class TetherClient {
 
     private var boundService: ITetherService? = null
     private var pendingBind: CompletableDeferred<ITetherService>? = null
 
-    /**
-     * The app process outlives the shell process — it stayed alive at
-     * oom_score_adj 0 through every observed death — so without this the UI
-     * keeps showing CONNECTED for a session that no longer exists.
-     */
     var onSessionLost: (() -> Unit)? = null
 
     private var deathRecipient: IBinder.DeathRecipient? = null
@@ -123,22 +95,12 @@ class TetherClient {
     private val userServiceArgs = Shizuku.UserServiceArgs(
         ComponentName(BuildConfig.APPLICATION_ID, TetherService::class.java.name),
     )
-        // The test network is tied to a Binder token held in this process, and
-        // a non-daemon service is reaped once the call returns, taking the
-        // network with it: "TestNetworkAgent: NetworkAgent channel lost" about
-        // four seconds after start() returned, with the upstream reverting.
+
         .daemon(true)
-        // Without a tag Shizuku keys each service record by a fresh UUID, so
-        // every bind creates a *new* daemon that unbind cannot reach — leaking
-        // a shell process per session, each holding its TUN's fd and keeping
-        // the interface alive in the kernel.
+
         .tag(SERVICE_TAG)
         .processNameSuffix("probe")
-        // Shizuku turns this into "-Xcompiler-option --debuggable
-        // -XjdwpProvider:adbconnection" on the app_process command line, which
-        // costs the shell process its AOT code for the whole of its life. Worth
-        // it to attach a debugger to it; not worth it on a user's phone, where
-        // it only makes a start that is already the slowest part slower.
+
         .debuggable(BuildConfig.DEBUG)
         .version(TetherService.CONTRACT_VERSION)
 
@@ -162,10 +124,6 @@ class TetherClient {
         }
     }
 
-    /**
-     * Reuses a live binding; discards a dead one, which after an APK update is
-     * a stale shell process (R2.5, T-5).
-     */
     private suspend fun service(): ITetherService {
         boundService?.let { existing ->
             if (existing.asBinder().pingBinder()) return existing
@@ -181,18 +139,6 @@ class TetherClient {
         return bound
     }
 
-    /**
-     * Restates a timeout as what actually went wrong.
-     *
-     * R8 renames TimeoutCancellationException, so the class name the UI shows
-     * is a letter and a digit and the message is kotlinx's, which knows nothing
-     * about what was being awaited. Every distinct way the shell process can
-     * fail to appear -- never started, started and exited, still starting --
-     * reached the user as the same uninformative string.
-     *
-     * IllegalStateException survives minification with its name intact, being
-     * a platform class.
-     */
     private suspend fun awaitBind(deferred: CompletableDeferred<ITetherService>): ITetherService =
         try {
             withTimeout(BIND_TIMEOUT_MS) { deferred.await() }
@@ -207,11 +153,6 @@ class TetherClient {
             )
         }
 
-    /**
-     * onServiceDisconnected does not cover this: the shell process is a child
-     * of the Shizuku server, and when that server dies the child exits without
-     * the binding being torn down. Linking to the binder catches both.
-     */
     private fun observeDeath(bound: ITetherService) {
         deathRecipient = null
 
@@ -224,7 +165,7 @@ class TetherClient {
         runCatching { binder.linkToDeath(recipient, 0) }
             .onSuccess { deathRecipient = recipient }
             .onFailure {
-                // Already dead: the caller's next call fails and surfaces it.
+
                 boundService = null
             }
     }
@@ -235,12 +176,6 @@ class TetherClient {
         bound.runProbes(attemptTethering, AVAILABILITY_TIMEOUT_MS)
     }
 
-    /**
-     * Resolves the two APIs the app rests on, at shell UID.
-     *
-     * Verifies the contract first: an older daemon has no such method and
-     * raises AbstractMethodError, which says nothing about compatibility.
-     */
     suspend fun checkCompatibility(): List<CapabilityResult> = withContext(Dispatchers.IO) {
         val bound = service()
         verifyContract(bound)
@@ -253,40 +188,18 @@ class TetherClient {
         bound.start(logging)
     }
 
-    /**
-     * No-ops when unbound rather than binding to deliver: an unbound process
-     * holds no session to log, and start() carries the setting across.
-     */
     fun setLogging(enabled: Boolean) {
         runCatching { boundService?.setLogging(enabled) }
     }
 
-    /**
-     * Binds if nothing is bound — the stable tag reaches the daemon already
-     * running, so a stop from a process that never bound (the notification
-     * action, a restarted service) still finds the session it needs to end.
-     */
     suspend fun stop(): String = withContext(Dispatchers.IO) {
         service().stop()
     }
 
-    /**
-     * Empties the shell process's half of the log.
-     *
-     * Binds to deliver this, unlike [setLogging]: a setting survives being
-     * skipped, but a file left unwritten stays written, and the shell's file
-     * holds most of the history — the screen would reload and show the clear
-     * had not happened.
-     *
-     * @return null on success, else why the entries could not be dropped, for
-     *   a UI that should not claim more than it did.
-     */
     suspend fun clearLog(): String? = withContext(Dispatchers.IO) {
         runCatching {
             val bound = service()
 
-            // clearLog is newer than daemons that may still be running, where
-            // it raises an AbstractMethodError saying nothing about why.
             verifyContract(bound)
             bound.clearLog()
         }.fold(
@@ -295,17 +208,6 @@ class TetherClient {
         )
     }
 
-    /**
-     * Drops a downstream left tethered by a shell process that died — SIGTERM
-     * leaves the hotspot up and tethering falling back to cellular with clients
-     * attached, which the in-process shutdown hook cannot catch.
-     *
-     * Binds a *new* shell process purely to issue the teardown: the old one is
-     * gone with the session object it owned, but stop() on a fresh instance
-     * still drops the downstream that outlived it.
-     *
-     * @return null on success, else why the downstream could not be dropped.
-     */
     suspend fun releaseOrphanedDownstream(): String? = withContext(Dispatchers.IO) {
         runCatching { service().stop() }
             .fold(
@@ -320,14 +222,6 @@ class TetherClient {
         service().status
     }
 
-    /**
-     * T-5: a shell process left over from a previous APK must not be used.
-     *
-     * The daemon survives APK replacement and does not reload its classes, so a
-     * rebuilt implementation keeps running old code behind an unchanged AIDL
-     * surface. Keying the version on the build makes that detectable — a debug
-     * build carries its APK timestamp, so any reinstall invalidates a daemon.
-     */
     private fun verifyContract(bound: ITetherService) {
         val remote = bound.contractVersion
         check(remote == TetherService.CONTRACT_VERSION) {
@@ -336,20 +230,8 @@ class TetherClient {
         }
     }
 
-    /**
-     * Keeps the daemon, and with it the test network the session depends on:
-     * leaving the UI must not drop tethered clients. Only stop() ends a session.
-     */
     fun unbind() = releaseBinding(shouldTerminate = false)
 
-    /**
-     * Safe only once a session is torn down, and necessary then: the daemon
-     * holds the TUN's fd, so a process outliving its session keeps the
-     * interface alive in the kernel whatever teardown closes on this side. An
-     * evening of starts and stops left fourteen orphaned daemons and eight
-     * surviving testtun interfaces, and tethering picking one of those is what
-     * failed the next session's upstream check.
-     */
     fun unbindAndStopDaemon() = releaseBinding(shouldTerminate = true)
 
     private fun releaseBinding(shouldTerminate: Boolean) {
@@ -363,25 +245,11 @@ class TetherClient {
     }
 
     private companion object {
-        /**
-         * Stable across binds and across both controllers that reach it — the
-         * service's and the ViewModel's — so they address one shell process.
-         */
+
         private const val SERVICE_TAG = "shizzi-session"
 
-        /**
-         * Deliberately longer than the 30s Shizuku gives a user service to
-         * start (UserServiceRecord.setStartingTimeout), so the server's own
-         * deadline is the one that decides. At 10s this expired while the shell
-         * process was still legitimately starting, and reported a failure for a
-         * bind that had not failed.
-         *
-         * Covers only the bind. The probe run is not bounded by this: Q5 waits
-         * up to 45s for upstream selection to settle.
-         */
         const val BIND_TIMEOUT_MS = 35_000L
 
-        /** R3.3 suggests a 10s bound on test-network availability. */
         const val AVAILABILITY_TIMEOUT_MS = 10_000
     }
 }

--- a/app/src/main/java/dev/shizzi/TetherService.kt
+++ b/app/src/main/java/dev/shizzi/TetherService.kt
@@ -4,24 +4,10 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 
-/**
- * Shizuku UserService implementation, running in the shell (uid 2000) process.
- *
- * Both constructors are invoked reflectively by Shizuku; neither may be removed.
- */
 class TetherService : ITetherService.Stub {
 
     private val context: Context
 
-    /**
-     * Resolved on first call rather than in the constructor.
-     *
-     * Shizuku's UserService.create catches whatever a constructor throws,
-     * returns null, and ServiceStarter exits: no binder is ever sent, and the
-     * app waits out its bind timeout with nothing to report but the timeout.
-     * Rebasing is the step here most likely to fail on a build that has moved
-     * its internals, so it has to fail where a caller can hear about it.
-     */
     private val shellContext: Context by lazy { asShellContext(context) }
     private val runner: ProbeRunner by lazy { ProbeRunner(shellContext) }
     private val session: TetherSession by lazy { TetherSession(shellContext) }
@@ -30,11 +16,6 @@ class TetherService : ITetherService.Stub {
     @Suppress("unused")
     constructor() : this(acquireSystemContext())
 
-    /**
-     * Shizuku prefers this constructor and supplies a context packaged as
-     * "android", so the rebasing has to be reachable from here and not only
-     * from the no-arg path, which is the one that never runs.
-     */
     constructor(context: Context) {
         this.context = context
         liveInstance = this
@@ -48,10 +29,6 @@ class TetherService : ITetherService.Stub {
             .getOrElse { failure -> sessionError("start", failure) }
     }
 
-    /**
-     * Also tears down the probe runner: the two paths hold separate resources,
-     * so stopping only the session leaves the other's test network alive.
-     */
     override fun stop(): String {
         runCatching { runner.teardown() }
             .onFailure { failure -> Log.w(TAG, "stop: probe teardown ${failure.message}") }
@@ -64,48 +41,25 @@ class TetherService : ITetherService.Stub {
         runCatching { session.status() }
             .getOrElse { failure -> sessionError("getStatus", failure) }
 
-    /** Pushed by the app, which writes few entries and holds the only DataStore. */
     override fun setLogging(enabled: Boolean) {
         SessionLog.setEnabled(enabled)
     }
 
-    /**
-     * Never throws across the binder: the app reads a capability the report
-     * omits as absent, which is the honest answer when the check itself broke.
-     */
     override fun checkCompatibility(): String =
         runCatching { compatibility.run().toJson() }
             .getOrElse { failure -> errorReport("checkCompatibility", failure) }
 
-    /**
-     * Empties the file this process writes; the app clears its own half.
-     *
-     * Never throws across the binder — a failed clear is not worth a
-     * RemoteException, and the UI re-reads the file anyway.
-     */
     override fun clearLog() {
         runCatching { SessionLog.clear() }
             .onFailure { failure -> Log.w(TAG, "clearLog: ${failure.message}") }
     }
 
-    /**
-     * Never throws across the binder: a RemoteException loses the diagnostic
-     * detail, which is the entire point of a probe run (R7.5).
-     */
     override fun runProbes(attemptTethering: Boolean, availabilityTimeoutMs: Int): String =
         publish(
             runCatching { runner.run(attemptTethering, availabilityTimeoutMs) }
                 .getOrElse { failure -> errorReport("runProbes", failure) },
         )
 
-    /**
-     * Writes the probe [report] where it can be read off-device.
-     *
-     * Only probe runs publish — start and stop would overwrite the report with
-     * a status SessionLog already keeps. Written from this process because uid
-     * 2000 can write outside app-private storage, so it reads without run-as,
-     * and ungated because logcat truncates the long lines a report is made of.
-     */
     private fun publish(report: String): String {
         runCatching { java.io.File(REPORT_PATH).writeText(report) }
             .onFailure { failure -> Log.w(TAG, "publish: ${failure.message}") }
@@ -114,13 +68,6 @@ class TetherService : ITetherService.Stub {
         return report
     }
 
-    /**
-     * A failure in the shape the app folds into its screen.
-     *
-     * Not [errorReport], which is a probe report: applyOutcome reads "state"
-     * and a report carries none, so a start failing this way would render as an
-     * idle screen rather than an error. Only [runProbes] is read as a report.
-     */
     private fun sessionError(operation: String, failure: Throwable): String {
         Log.e(TAG, "$operation failed", failure)
         return org.json.JSONObject().apply {
@@ -140,20 +87,9 @@ class TetherService : ITetherService.Stub {
     }
 
     companion object {
-        /**
-         * Identifies the build, so a stale shell process is detected (R2.5).
-         *
-         * Derived from the sources rather than hand-bumped: the daemon survives
-         * APK replacement without reloading its classes, so the implementation
-         * can change while the AIDL surface stays identical — the exact case a
-         * hand-maintained number misses.
-         */
+
         val CONTRACT_VERSION = BuildConfig.SERVICE_BUILD_ID
 
-        /**
-         * Keeps the session alive across unbinds — Shizuku holds the stub only
-         * while a client is bound, but the user starts tethering and leaves.
-         */
         @Suppress("unused")
         @JvmStatic
         private var liveInstance: TetherService? = null
@@ -161,10 +97,8 @@ class TetherService : ITetherService.Stub {
         private const val TAG = "TetherService"
         private const val STACK_TRACE_CHARS = 4000
 
-        /** Public so the settings screen can name it without restating the path. */
         const val REPORT_PATH = "/data/local/tmp/shizzi-probe-report.json"
 
-        /** The shell package, whose UID (2000) this process actually runs as. */
         private const val SHELL_PACKAGE = "com.android.shell"
 
         @SuppressLint("PrivateApi", "DiscouragedPrivateApi")
@@ -174,14 +108,6 @@ class TetherService : ITetherService.Stub {
             return activityThread.getMethod("getSystemContext").invoke(systemMain) as Context
         }
 
-        /**
-         * Rebases [context] onto the shell package.
-         *
-         * Framework services validate the calling package against the calling
-         * UID, and getSystemContext reports "android" from a UID-2000 process:
-         * "Package android does not belong to 2000", which is how the first
-         * device runs of setupTestNetwork failed.
-         */
         private fun asShellContext(context: Context): Context {
             val rebased = runCatching { context.createPackageContext(SHELL_PACKAGE, 0) }
                 .getOrElse { failure ->
@@ -195,17 +121,6 @@ class TetherService : ITetherService.Stub {
             return rebased
         }
 
-        /**
-         * Repoints ContextImpl.mAttributionSource at the shell package.
-         *
-         * createPackageContext fixes getPackageName but not getOpPackageName,
-         * which is what services actually attribute by. On API 36 that reads
-         * mAttributionSource; the older mOpPackageName field no longer backs
-         * it, so writing that one succeeded and changed nothing.
-         *
-         * @throws IllegalStateException so a future release moving this again
-         *   fails loudly instead of producing another silent no-op.
-         */
         private fun forceOpPackageName(context: Context) {
             runCatching {
                 val field = context.javaClass.getDeclaredField("mAttributionSource")

--- a/app/src/main/java/dev/shizzi/TetherSession.kt
+++ b/app/src/main/java/dev/shizzi/TetherSession.kt
@@ -5,16 +5,8 @@ import android.os.Build
 import android.util.Log
 import org.json.JSONObject
 
-/** What the session is currently doing, as reported to the UI. */
 enum class SessionState { IDLE, STARTING, ACTIVE, ERROR }
 
-/**
- * Owns a long-lived protected-tethering session inside the shell process. The
- * probe runner answers questions and tears down immediately; this holds the
- * session up until asked to stop.
- *
- * The start ordering in [bringUp] is load-bearing — see the notes there.
- */
 class TetherSession(private val context: Context) {
 
     private val testNetworkApi = TestNetworkApi(context)
@@ -25,7 +17,6 @@ class TetherSession(private val context: Context) {
     private var detail = "not started"
     private var interfaceName: String? = null
 
-    /** When the session went ACTIVE, for the summary [stop] writes. */
     private var activeSince: Long = 0
     private var watchdog: SessionWatchdog? = null
     private val teardown = SessionTeardown(context)
@@ -34,17 +25,12 @@ class TetherSession(private val context: Context) {
 
     val isActive: Boolean get() = state == SessionState.ACTIVE
 
-    /**
-     * Brings the session up, tearing down on any failure.
-     *
-     * @return JSON status; never throws, so the UI always has something to show.
-     */
     fun start(): String {
         if (isActive) return status()
 
         state = SessionState.STARTING
         SessionLog.info("session start requested")
-        // The first thing worth knowing about a log someone sends in.
+
         SessionLog.info(
             "device: ${Build.MANUFACTURER} ${Build.MODEL}, " +
                 "android ${Build.VERSION.RELEASE} (sdk ${Build.VERSION.SDK_INT}), " +
@@ -64,15 +50,6 @@ class TetherSession(private val context: Context) {
             }
     }
 
-    /**
-     * Establishes the session in the order upstream selection requires: TUN,
-     * then preference, then downstream. A live test network has to exist when
-     * tethering goes looking, or it selects from what it already knows — on a
-     * device carrying a stale entry from a previous boot, that is a dead
-     * interface holding the slot the real TUN needs.
-     *
-     * @throws IllegalStateException naming the step that failed.
-     */
     private fun bringUp(): String {
         val group = SessionResources(testNetworkApi, context.connectivityManager())
         resources = group
@@ -100,7 +77,6 @@ class TetherSession(private val context: Context) {
         return status()
     }
 
-    /** Stops the session if the tunnel stops being the sole upstream (R6.1). */
     private fun startWatchdog(name: String) {
         val guard = SessionWatchdog(name) { problem ->
             SessionLog.warn("upstream drift: $problem")
@@ -110,11 +86,6 @@ class TetherSession(private val context: Context) {
         guard.start()
     }
 
-    /**
-     * A teardown failure is kept alongside [problem], not overwritten by it:
-     * "the hotspot is still up" is the more dangerous of the two and the one
-     * the plain message hides. The caller logs its own cause.
-     */
     private fun tearDownAfter(problem: String) {
         stop()
 
@@ -126,15 +97,6 @@ class TetherSession(private val context: Context) {
         }
     }
 
-    /**
-     * Driven false-then-true, because the framework acts on the *change*: an
-     * already-true preference set true again is a no-op, and the new TUN then
-     * appears with nothing prompting tethering to look at it.
-     *
-     * That was the intermittent failure — stop, start, and the upstream never
-     * moves off the previous selection for the whole verify window, while the
-     * next start works because its teardown had just cleared the preference.
-     */
     private fun preferTestNetworks() {
         val api = TetheringPreferenceApi(context)
         runCatching { api.setPreferTestNetworks(false) }
@@ -142,11 +104,6 @@ class TetherSession(private val context: Context) {
         api.setPreferTestNetworks(true)
     }
 
-    /**
-     * Cycles the hotspot if one is already running, so the user does not have
-     * to have enabled tethering first — failing them with an upstream error
-     * would make the app's internal sequencing their problem.
-     */
     private fun restartDownstream() {
         val control = DownstreamControl(context)
         control.stopWifiTethering()
@@ -157,22 +114,12 @@ class TetherSession(private val context: Context) {
         awaitDownstreamTethered()
     }
 
-    /**
-     * Tethered, not merely requested: startWifiTethering returns on acceptance,
-     * well before the downstream is up, and tethering with nothing to serve
-     * never looks for an upstream — `Upstream wanted` stays false and
-     * verifyUpstream times out against an empty list. That was every "tethering
-     * reports []" failure on the device.
-     *
-     * A timeout here is not fatal; verifyUpstream is the real gate.
-     */
     private fun awaitDownstreamTethered() {
         val deadline = System.currentTimeMillis() + DOWNSTREAM_SETTLE_MS
         val downstream = DownstreamInspector()
 
         while (System.currentTimeMillis() < deadline) {
-            // Non-null means something *is* tethered, which is what this waits
-            // for -- the same reading means "still up" during teardown.
+
             if (downstream.findTetheredDownstream() != null) {
                 SessionLog.info("downstream tethered")
                 return
@@ -183,12 +130,6 @@ class TetherSession(private val context: Context) {
         SessionLog.warn("downstream not tethered after ${DOWNSTREAM_SETTLE_MS}ms; continuing")
     }
 
-    /**
-     * R4.3: startup is provisional until the owned TUN is the sole upstream.
-     *
-     * @throws IllegalStateException so [start] tears down rather than leaving
-     *   clients on a physical upstream.
-     */
     private fun verifyUpstream(name: String) {
         val deadline = System.currentTimeMillis() + UPSTREAM_SETTLE_MS
         var observed = liveUpstreams(name)
@@ -204,30 +145,18 @@ class TetherSession(private val context: Context) {
     private fun liveUpstreams(owned: String): List<String> =
         inspector.observe().liveInterfaceNames(owned)
 
-    /**
-     * Releases everything in fail-closed order: downstream first (R6.1).
-     *
-     * Reports ERROR when the downstream could not be confirmed down. Claiming
-     * "stopped" while the hotspot is still broadcasting is the one lie with
-     * real consequence here — clients stay connected through the physical
-     * upstream, which is what the session exists to prevent.
-     */
     fun stop(): String {
         watchdog?.stop()
         watchdog = null
         vpn.stop()
         teardown.removeShutdownHook()
 
-        // Before anything is released: /proc/net/dev stops knowing the
-        // interface once it is gone. Null if the session never went active.
         val summary = if (activeSince == 0L) null else sessionSummary()
 
         val downstreamProblem = teardown.releaseDownstream()
 
         teardown.releaseUpstreamSelection(interfaceName)
 
-        // release() already logs each problem; this keeps the count in the
-        // teardown's own narrative rather than leaving it implicit.
         val releaseProblems = resources?.release().orEmpty()
         resources = null
 
@@ -247,10 +176,6 @@ class TetherSession(private val context: Context) {
         return status()
     }
 
-    /**
-     * Only for a session that reached ACTIVE: a failed start tears down through
-     * the same path, and summarising it reports zeroes over the real finding.
-     */
     private fun sessionSummary(): String {
         val traffic = interfaceName?.let(InterfaceCounters::read) ?: Traffic()
         val elapsed = when (activeSince) {
@@ -262,7 +187,6 @@ class TetherSession(private val context: Context) {
             "${Traffic.format(traffic.up)} up, ${Traffic.format(traffic.down)} down"
     }
 
-    /** Whole units only: a log line reporting a session's length is not a stopwatch. */
     private fun formatDuration(millis: Long): String {
         val totalSeconds = millis / 1000
         val hours = totalSeconds / 3600
@@ -280,13 +204,9 @@ class TetherSession(private val context: Context) {
         put("state", state.name)
         put("detail", detail)
         put("interface", interfaceName ?: JSONObject.NULL)
-        // A boolean rather than the handle: the handle is an opaque framework
-        // token, and nothing on the far side of the binder should render it.
+
         put("isVpnBound", vpn.isBound)
 
-        // Different sources on purpose: bytes from /proc in process every call,
-        // the device count from dumpsys behind its own rate limit. That split
-        // is what keeps a fast poll affordable.
         val traffic = interfaceName?.let(InterfaceCounters::read) ?: Traffic()
         put("bytesUp", traffic.up)
         put("bytesDown", traffic.down)
@@ -303,7 +223,6 @@ class TetherSession(private val context: Context) {
         const val TUN_ADDRESS = "192.0.2.2"
         const val TUN_PREFIX_LENGTH = 24
 
-        /** The IPv6 counterpart, from the documentation range so it cannot collide. */
         const val TUN_ADDRESS_V6 = "2001:db8::2"
         const val TUN_PREFIX_LENGTH_V6 = 64
 
@@ -312,12 +231,6 @@ class TetherSession(private val context: Context) {
         const val UPSTREAM_SETTLE_MS = 8_000L
         const val UPSTREAM_POLL_MS = 500L
 
-        /**
-         * How long to wait for the hotspot to come up before building the TUN.
-         *
-         * Generous because this covers a cold start of the Wi-Fi AP, which on
-         * a real device takes seconds rather than milliseconds.
-         */
         const val DOWNSTREAM_SETTLE_MS = 10_000L
         const val DOWNSTREAM_POLL_MS = 500L
     }

--- a/app/src/main/java/dev/shizzi/Traffic.kt
+++ b/app/src/main/java/dev/shizzi/Traffic.kt
@@ -2,17 +2,8 @@ package dev.shizzi
 
 import kotlin.math.roundToLong
 
-/**
- * Bytes carried by a session, from the tethered device's point of view: "up" is
- * what those devices sent. The notification describes what the user's other
- * devices are doing, not what the phone is doing.
- */
 data class Traffic(val up: Long = 0, val down: Long = 0) {
 
-    /**
-     * Decimal units rather than binary, so 1.4 GB here agrees with Android's
-     * own data usage screen, which counts in powers of ten.
-     */
     companion object {
         private const val UNIT = 1000.0
         private val SCALE = listOf("B", "KB", "MB", "GB", "TB")
@@ -27,7 +18,6 @@ data class Traffic(val up: Long = 0, val down: Long = 0) {
                 step++
             }
 
-            // "9.4 MB" but "94 MB" — past ten, the decimal is noise.
             val rendered = when {
                 value < 10 -> String.format("%.1f", value)
                 else -> value.roundToLong().toString()

--- a/app/src/main/java/dev/shizzi/UpstreamInspector.kt
+++ b/app/src/main/java/dev/shizzi/UpstreamInspector.kt
@@ -4,28 +4,12 @@ import java.io.BufferedReader
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-/** What the tethering stack currently reports as its upstream. */
 data class UpstreamObservation(
     val rawOutput: String,
     val interfaceNames: List<String>,
     val didTimeout: Boolean,
 ) {
-    /**
-     * [interfaceNames] minus any interface the kernel no longer has.
-     *
-     * Tethering keeps naming destroyed interfaces: its detach needs the
-     * interface to exist, so once the TUN is gone the reference is stuck for
-     * the boot. Teardown ordering stops one being created; this is what saves a
-     * device that already has one from failing every future session.
-     *
-     * Dropping only *absent* interfaces leaves the guarantee intact — the risk
-     * is clients routing over a real physical upstream, and an interface that
-     * does not exist carries nothing. Anything present and competing is still a
-     * hard failure.
-     *
-     * @param owned kept unconditionally: a check that raced the session's own
-     *   TUN into existence must not discard it.
-     */
+
     fun liveInterfaceNames(owned: String): List<String> {
         val (live, absent) = interfaceNames.partition { it == owned || interfaceExists(it) }
         if (absent.isNotEmpty()) {
@@ -35,26 +19,13 @@ data class UpstreamObservation(
     }
 }
 
-/**
- * Sysfs rather than shelling out to `ip`: this runs on the watchdog's polling
- * path, so the answer is one stat instead of a process launch. Unreadable
- * counts as present, keeping the caller failing closed.
- */
 private fun interfaceExists(name: String): Boolean =
     runCatching { java.io.File("/sys/class/net/$name").exists() }.getOrDefault(true)
 
-/**
- * Reads tethering upstream state out of `dumpsys tethering`.
- *
- * R4.6: drained concurrently under a short deadline, so a stalled OEM tethering
- * service cannot wedge teardown. Both streams get their own thread — a process
- * that fills an undrained pipe buffer blocks forever whatever waitFor says.
- */
 class UpstreamInspector(private val deadlineMs: Long = DEFAULT_DEADLINE_MS) {
 
     fun observe(): UpstreamObservation = run("tethering")
 
-    /** For facts tethering's own dump reports only historically. */
     fun observeWifi(): UpstreamObservation = run("wifi")
 
     private fun run(service: String): UpstreamObservation {
@@ -86,21 +57,6 @@ class UpstreamInspector(private val deadlineMs: Long = DEFAULT_DEADLINE_MS) {
         return if (err.isBlank()) out else "$out\n[stderr]\n$err"
     }
 
-    /**
-     * Reads only lines stating which upstream tethering has *selected*. An
-     * earlier version matched any "Upstream:", which caught the BPF rule tables:
-     *
-     *     IPv4 Upstream: proto [inDstMac] iif(iface) src -> nat -> dst ...
-     *
-     * Those hold rules for interfaces that no longer exist — a destroyed TUN
-     * was still listed seven sessions later, failing every start with "expected
-     * only testtun77, tethering reports [testtun70]" while `ip link` showed no
-     * TUN at all. Rule tables describe what was, not what is.
-     *
-     * The format is not contractual, so the match stays loose within that
-     * narrower set and [rawOutput] is kept so a parse miss is visible rather
-     * than silently wrong.
-     */
     private fun parseUpstreamInterfaces(output: String): List<String> {
         val interesting = output.lineSequence()
             .map(String::trim)
@@ -118,11 +74,6 @@ class UpstreamInspector(private val deadlineMs: Long = DEFAULT_DEADLINE_MS) {
     companion object {
         const val DEFAULT_DEADLINE_MS = 3_000L
 
-        /**
-         * Prefixes rather than substrings, and no bare "Upstream:" — that
-         * matched the nested BPF rule-table headers and pulled in interfaces
-         * already destroyed.
-         */
         private val UPSTREAM_HINTS = listOf(
             "current upstream interface(s):",
             "current upstream:",
@@ -131,7 +82,6 @@ class UpstreamInspector(private val deadlineMs: Long = DEFAULT_DEADLINE_MS) {
             "mCurrentUpstream",
         )
 
-        /** Interface-shaped tokens: testtun0, wlan0, rmnet_data1, ... */
         private val INTERFACE_PATTERN =
             Regex("""\b(testtun\d+|wlan\d+|rmnet[a-z_]*\d*|eth\d+|ap\d+|swlan\d+)\b""")
     }

--- a/app/src/main/java/dev/shizzi/VpnUpstream.kt
+++ b/app/src/main/java/dev/shizzi/VpnUpstream.kt
@@ -2,15 +2,6 @@ package dev.shizzi
 
 import android.content.Context
 
-/**
- * Keeps the datapath pinned to a VPN for as long as the session has one, so
- * TetherSession runs the lifecycle without also arbitrating what counts as a
- * VPN worth binding to.
- *
- * Absence is not a failure — a session with no VPN runs unbound and tethers
- * normally. What binding buys is that once one *is* adopted, losing it fails
- * the dials instead of quietly falling back to the physical network.
- */
 class VpnUpstream(
     private val context: Context,
     private val onLost: (String) -> Unit,
@@ -18,16 +9,11 @@ class VpnUpstream(
 
     private var watchdog: VpnWatchdog? = null
 
-    /** 0 while unbound; the adopted VPN's handle once one is in use. */
     var handle = UNBOUND
         private set
 
     val isBound: Boolean get() = handle != UNBOUND
 
-    /**
-     * Called before the downstream comes up so nothing can dial unbound: the
-     * datapath exists by now, and no client can be attached yet.
-     */
     fun follow(group: SessionResources) {
         val watcher = VpnWatchdog(context.connectivityManager()) { binding ->
             apply(group, binding)
@@ -65,7 +51,7 @@ class VpnUpstream(
     }
 
     private companion object {
-        /** No VPN adopted; the datapath dials over the default network. */
+
         const val UNBOUND = 0L
     }
 }

--- a/app/src/main/java/dev/shizzi/VpnWatchdog.kt
+++ b/app/src/main/java/dev/shizzi/VpnWatchdog.kt
@@ -5,30 +5,13 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import java.util.concurrent.atomic.AtomicBoolean
 
-/** What the poller last observed, as the session needs to act on it. */
 sealed interface VpnBinding {
 
-    /** A VPN to pin the datapath to; [handle] feeds Session.setNetwork. */
     data class Adopted(val handle: Long) : VpnBinding
 
-    /** The adopted VPN is gone and has stayed gone. Fail closed. */
     data class Lost(val problem: String) : VpnBinding
 }
 
-/**
- * Follows the VPN the datapath's sockets are pinned to, and reports its loss.
- * The datapath dials from this process, so the question is only authoritative
- * here.
- *
- * Polls rather than registering a callback: from the shell UID
- * registerNetworkCallback is rejected with "Package android does not belong to
- * 2000", while getAllNetworks carries no such check.
- *
- * A session that never sees a VPN runs unbound and is never torn down by this.
- * Losing an adopted one is a failure — and binding is what makes the promise
- * safe, since those sockets stop working rather than falling back, so the
- * window before this notices carries no untunnelled traffic.
- */
 class VpnWatchdog(
     private val connectivityManager: ConnectivityManager,
     private val onChange: (VpnBinding) -> Unit,
@@ -37,20 +20,10 @@ class VpnWatchdog(
     private val isRunning = AtomicBoolean(false)
     private var thread: Thread? = null
 
-    /** 0 while unbound, a handle once adopted. Touched only on the poll thread. */
     private var boundHandle = UNBOUND
 
-    /**
-     * One miss is not evidence: a VPN app restarting can leave a single poll
-     * empty, and a one-sample teardown turns that into a dropped hotspot.
-     */
     private var consecutiveMisses = 0
 
-    /**
-     * Adopts whatever VPN is up now, so a session starting under one is bound
-     * before any client can dial. Mutates [boundHandle] rather than only
-     * reporting it, or the first poll reads the same VPN as a change.
-     */
     fun adoptCurrentVpn(): Long {
         boundHandle = currentVpnHandle()
         return boundHandle
@@ -65,7 +38,6 @@ class VpnWatchdog(
         }
     }
 
-    /** Safe to call from [onChange], for the reason SessionWatchdog.stop documents. */
     fun stop() {
         isRunning.set(false)
 
@@ -87,20 +59,11 @@ class VpnWatchdog(
         }
     }
 
-    /**
-     * @return null while nothing needs to change, else what the session must do.
-     *
-     * The strike counter counts *absence*, never *change*: a reconnecting VPN
-     * comes back as a new Network with a new handle and no stable identity
-     * across the gap, so treating a changed handle as loss would tear the
-     * session down on every reconnect.
-     */
     private fun evaluate(): VpnBinding? {
         val observed = currentVpnHandle()
 
         if (observed != UNBOUND) return adopt(observed)
 
-        // Never adopted: this session makes no VPN promise to break.
         if (boundHandle == UNBOUND) return null
 
         consecutiveMisses++
@@ -114,7 +77,6 @@ class VpnWatchdog(
         return VpnBinding.Lost(VPN_LOST_DETAIL)
     }
 
-    /** @return null when [observed] is already the bound network. */
     private fun adopt(observed: Long): VpnBinding? {
         consecutiveMisses = 0
         if (observed == boundHandle) return null
@@ -127,15 +89,6 @@ class VpnWatchdog(
 
     private fun currentVpnHandle(): Long = findVpn()?.let(::handleOf) ?: UNBOUND
 
-    /**
-     * The first network reporting TRANSPORT_VPN; the session's own TUN carries
-     * TRANSPORT_TEST and cannot be mistaken for one. Two VPNs can coexist
-     * mid-handover, and picking the first beats refusing to pick — the handover
-     * then reads as a re-adopt next poll.
-     *
-     * A throw returns null without counting as a strike: a binder hiccup is not
-     * evidence the VPN is gone.
-     */
     private fun findVpn(): Network? = runCatching {
         connectivityManager.allNetworks.firstOrNull { candidate ->
             connectivityManager.getNetworkCapabilities(candidate)
@@ -158,10 +111,8 @@ class VpnWatchdog(
         const val UNBOUND = 0L
         const val POLL_INTERVAL_MS = 5_000L
 
-        /** Two strikes, matching SessionWatchdog: one miss is not evidence. */
         const val MISSES_BEFORE_TEARDOWN = 2
 
-        /** Reaches the user verbatim, through the session's detail string. */
         const val VPN_LOST_DETAIL =
             "VPN disconnected. Session stopped to keep devices protected."
     }

--- a/app/src/main/java/dev/shizzi/ui/ClearLogToast.kt
+++ b/app/src/main/java/dev/shizzi/ui/ClearLogToast.kt
@@ -5,15 +5,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.getValue
 
-/**
- * Asks before emptying the log.
- *
- * A toast, not a dialog: nothing here dims the screen behind a modal, and
- * clearing a log is not grave enough to be the first thing that does — but it
- * is irreversible, so not a single tap either. CLEAR confirms; every other way
- * out of a toast cancels. The destructive path needs an explicit press, the
- * safe one is whatever happens by accident.
- */
 @Composable
 fun ClearLogToast(
     isConfirming: Boolean,
@@ -21,8 +12,7 @@ fun ClearLogToast(
     onConfirm: () -> Unit,
     onCancel: () -> Unit,
 ) {
-    // Read when CLEAR is pressed, which may be several recompositions after
-    // the toast was built.
+
     val confirm by rememberUpdatedState(onConfirm)
     val cancel by rememberUpdatedState(onCancel)
 
@@ -32,8 +22,6 @@ fun ClearLogToast(
             return@LaunchedEffect
         }
 
-        // The host runs onDismiss on every exit, the action's own included, so
-        // a bare cancel() here would also fire on confirm.
         var isAnswered = false
 
         toasts.show(
@@ -41,7 +29,7 @@ fun ClearLogToast(
                 key = ToastKeys.CLEAR_LOG,
                 message = "Clear the log?",
                 detail = "This action cannot be undone.",
-                // A question that timed out would be answered by inattention.
+
                 duration = ToastDuration.Indefinite,
                 action = ToastAction("Clear") {
                     isAnswered = true
@@ -53,11 +41,6 @@ fun ClearLogToast(
     }
 }
 
-/**
- * Reports what a clear actually emptied, which is not always all of it: the
- * shell's file holds most of the log and is reachable only through Shizuku, so
- * a failed call leaves entries that "Log cleared" would be lying about.
- */
 fun clearedToast(problem: String?): Toast = when (problem) {
     null -> Toast(
         key = ToastKeys.CLEAR_LOG,

--- a/app/src/main/java/dev/shizzi/ui/ConnectButton.kt
+++ b/app/src/main/java/dev/shizzi/ui/ConnectButton.kt
@@ -22,15 +22,6 @@ private val ButtonWidth = 200.dp
 private val ButtonHeight = 56.dp
 private val SpinnerSize = 24.dp
 
-/**
- * Turquoise to start, neutral to stop: only starting is the primary action, and
- * a filled Stop would compete with the connected status glyph for the eye.
- * Not red either — ending your own session is not destructive.
- *
- * Goes neutral with a spinner while coming up, since a turquoise button that
- * ignores taps invites them; Cancel is the live control in that window. The
- * footprint never changes, so nothing reflows.
- */
 @Composable
 fun ConnectButton(
     label: String,
@@ -71,8 +62,7 @@ fun ConnectButton(
             else -> Text(
                 text = label.uppercase(),
                 style = ShizziTheme.typography.title,
-                // onPrimary only on the filled button; the neutral fill needs a
-                // colour that reads against the surface instead.
+
                 color = when (state) {
                     ConnectButtonState.START -> colors.onPrimary
                     ConnectButtonState.STOP -> colors.onSurface
@@ -83,18 +73,12 @@ fun ConnectButton(
     }
 }
 
-/** What the button is currently offering, which decides its fill and label colour. */
 enum class ConnectButtonState { START, STOP, LOADING, DISABLED }
 
-/**
- * Plain text rather than a second bordered box: two stacked surfaces would read
- * as equal choices, and cancelling is the lesser one.
- */
 @Composable
 fun CancelButton(onClick: () -> Unit) {
     Box(
-        // Sized to the touch minimum rather than to the text, which is shorter
-        // than a finger.
+
         modifier = Modifier
             .height(MinTouchTarget)
             .clickable(onClick = onClick),

--- a/app/src/main/java/dev/shizzi/ui/DiagnosticsToast.kt
+++ b/app/src/main/java/dev/shizzi/ui/DiagnosticsToast.kt
@@ -7,13 +7,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
 import dev.shizzi.DiagnosticsState
 
-/**
- * One toast across all three phases, keyed so each replaces the last: a run is
- * one event, and stacking "running" under "complete" claims both at once.
- *
- * Beside [SessionToasts] rather than inside it, since that derives from session
- * state — which a probe run does not touch, and both can be on screen together.
- */
 @Composable
 fun DiagnosticsToast(
     state: DiagnosticsState,
@@ -22,8 +15,6 @@ fun DiagnosticsToast(
 ) {
     val context = LocalContext.current
 
-    // EXPORT may be pressed several recompositions later; capturing directly
-    // would export the state from when the toast was built.
     val current by rememberUpdatedState(state)
 
     LaunchedEffect(state) {
@@ -33,7 +24,6 @@ fun DiagnosticsToast(
                 return@LaunchedEffect
             }
 
-            // Indefinite and undismissable: it ends when the run does.
             is DiagnosticsState.Running -> Toast(
                 key = ToastKeys.DIAGNOSTICS,
                 message = "Running diagnostics...",
@@ -45,8 +35,7 @@ fun DiagnosticsToast(
                 key = ToastKeys.DIAGNOSTICS,
                 message = "Diagnostics completed",
                 detail = phase.path,
-                // The export button is why this toast exists; four seconds to
-                // notice and reach it would make the action decorative.
+
                 duration = ToastDuration.Indefinite,
                 action = ToastAction("Export") {
                     (current as? DiagnosticsState.Complete)
@@ -55,7 +44,6 @@ fun DiagnosticsToast(
                 onDismiss = onDismiss,
             )
 
-            // A failed run produced no report, and the reason is in the log.
             is DiagnosticsState.Failed -> Toast(
                 key = ToastKeys.DIAGNOSTICS,
                 message = "Diagnostics failed",

--- a/app/src/main/java/dev/shizzi/ui/ExportReport.kt
+++ b/app/src/main/java/dev/shizzi/ui/ExportReport.kt
@@ -8,20 +8,10 @@ import dev.shizzi.BuildConfig
 import dev.shizzi.SessionLog
 import java.io.File
 
-/** Subdirectory of files/, matching the authority's declared path. */
 private const val EXPORT_DIR = "exports"
 
-/** One name, overwritten per export: the last report is the only one worth keeping. */
 private const val EXPORT_NAME = "shizzi-probe-report.json"
 
-/**
- * Writes its own copy from the [report] string rather than sharing the shell's
- * file: that lives in /data/local/tmp, which this process cannot read, and a
- * FileProvider can only serve paths inside app storage anyway.
- *
- * Failures are logged, not thrown — the user can already see where the report
- * landed, so crashing because no app accepts JSON costs more than it saves.
- */
 fun Context.exportReport(report: String) {
     val uri = runCatching { writeExport(report) }
         .getOrElse { failure ->
@@ -33,8 +23,7 @@ fun Context.exportReport(report: String) {
         .setType("application/json")
         .putExtra(Intent.EXTRA_STREAM, uri)
         .putExtra(Intent.EXTRA_SUBJECT, EXPORT_NAME)
-        // The receiving process has no claim on this file; the grant is what
-        // lets it read the uri, and it lasts only as long as the intent.
+
         .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
 
     try {

--- a/app/src/main/java/dev/shizzi/ui/HomePage.kt
+++ b/app/src/main/java/dev/shizzi/ui/HomePage.kt
@@ -21,11 +21,9 @@ import dev.shizzi.ui.theme.HeaderHeight
 import dev.shizzi.ui.theme.ScreenPadding
 import dev.shizzi.ui.theme.ShizziTheme
 
-/** What the button does, given what the session is doing. */
 private fun buttonLabel(status: UiStatus): String =
     if (status == UiStatus.CONNECTED) "Stop" else "Start"
 
-/** Derived here so the rule lives beside the state it reads. */
 private fun buttonState(state: SessionUiState): ConnectButtonState = when {
     state.status == UiStatus.LOADING -> ConnectButtonState.LOADING
     state.status == UiStatus.CONNECTED -> ConnectButtonState.STOP
@@ -33,11 +31,6 @@ private fun buttonState(state: SessionUiState): ConnectButtonState = when {
     else -> ConnectButtonState.DISABLED
 }
 
-/**
- * Three things vertically: the status glyph, the one button, and the session
- * detail pinned to the bottom edge. Errors and Shizuku prompts are toasts, so
- * nothing here moves when one arrives.
- */
 @Composable
 fun HomePage(
     state: SessionUiState,
@@ -55,15 +48,11 @@ fun HomePage(
 
         HomeBody(state = state, actions = actions)
 
-        // The VPN line rides with the status row, so both readings of "what is
-        // this session doing" sit together at the bottom edge.
         Column(
             modifier = Modifier.align(Alignment.BottomCenter),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // Space reserved either way: a VPN can be adopted mid-session with
-            // the screen open, and the status row must not shift down. Bottom-
-            // aligned so the line sits with the row it belongs to.
+
             Box(
                 modifier = Modifier.height(ShizziTheme.spacing.xxxl),
                 contentAlignment = Alignment.BottomCenter,
@@ -76,20 +65,12 @@ fun HomePage(
     }
 }
 
-/** Grouped so the screen takes two parameters rather than five. */
 data class HomeActions(
     val onToggle: () -> Unit,
     val onCancel: () -> Unit,
     val onOpenSettings: () -> Unit,
 )
 
-/**
- * Badge on the left, navigation on the right. No title — naming the one home
- * screen would state the obvious at the largest size on the page.
- *
- * One destination: the log now lives under Developer in settings, beside the
- * toggle deciding whether it records anything.
- */
 @Composable
 private fun HomeHeader(
     state: SessionUiState,
@@ -108,8 +89,6 @@ private fun HomeHeader(
 
         Spacer(Modifier.weight(1f))
 
-        // Muted: the connect button is what the screen is for, and a header
-        // glyph at full strength reads as its peer.
         ShizziIconButton(
             icon = Icons.Filled.Settings,
             contentDescription = "Settings",
@@ -119,17 +98,9 @@ private fun HomeHeader(
     }
 }
 
-/**
- * Guarded on the status as well as the flag: a session torn down for VPN loss
- * holds ERROR alongside the last VPN reading until the next publish.
- */
 private fun isShowingVpn(state: SessionUiState): Boolean =
     state.isVpnBound && state.status == UiStatus.CONNECTED
 
-/**
- * Cancel appears only while starting: stopping is already the fast path, and
- * cancelling that would leave the session in the state this app exists to avoid.
- */
 @Composable
 private fun HomeBody(state: SessionUiState, actions: HomeActions) {
     val isStarting = state.status == UiStatus.LOADING
@@ -141,9 +112,6 @@ private fun HomeBody(state: SessionUiState, actions: HomeActions) {
     ) {
         StatusIcon(status = state.status)
 
-        // Two of the largest step rather than an arbitrary value, keeping the
-        // gap on the scale. Preserves the distance from when a reserved VPN
-        // band sat here.
         Spacer(Modifier.height(ShizziTheme.spacing.xxxl * 2))
 
         ConnectButton(
@@ -152,8 +120,6 @@ private fun HomeBody(state: SessionUiState, actions: HomeActions) {
             onClick = actions.onToggle,
         )
 
-        // Reserved whether or not it is showing, so the button does not shift
-        // up and down as a session starts.
         Box(modifier = Modifier.height(ShizziTheme.spacing.xxxl)) {
             if (isStarting) CancelButton(onClick = actions.onCancel)
         }

--- a/app/src/main/java/dev/shizzi/ui/IconButtons.kt
+++ b/app/src/main/java/dev/shizzi/ui/IconButtons.kt
@@ -13,17 +13,8 @@ import androidx.compose.ui.unit.dp
 import dev.shizzi.ui.theme.MinTouchTarget
 import dev.shizzi.ui.theme.ShizziTheme
 
-/** Glyph size, small enough to sit inside the touch target with room around it. */
 private val IconSize = 24.dp
 
-/**
- * Unbordered, unlike every other interactive element: a header row of bordered
- * boxes would compete with the content it sits above.
- *
- * The tint carries the ranking, so it is the caller's: a button competing with
- * something on its screen takes the muted tone, while the default is full
- * strength for one that is the only way off a screen.
- */
 @Composable
 fun ShizziIconButton(
     icon: ImageVector,
@@ -45,10 +36,6 @@ fun ShizziIconButton(
     }
 }
 
-/**
- * Auto-mirrored for right-to-left locales. Full strength, unlike the settings
- * button it mirrors: back is the only way off the screen it sits on.
- */
 @Composable
 fun BackButton(onBack: () -> Unit) {
     ShizziIconButton(

--- a/app/src/main/java/dev/shizzi/ui/LogPage.kt
+++ b/app/src/main/java/dev/shizzi/ui/LogPage.kt
@@ -55,52 +55,19 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-/**
- * Fixed rather than measured: four digits at the log style's size outlasts what
- * a 1 MB cap holds, and measuring per frame would shift the rule between gutter
- * and text as the list scrolls past line 100.
- */
 private val GutterWidth = 44.dp
 
-/** Turquoise edge marking a selected row, and the width of the gutter rule. */
 private val SelectionEdge = 3.dp
 private val RuleWidth = 1.dp
 
-/** How much turquoise a selected row's background carries. */
 private const val SelectionTint = 0.12f
 
-/** Tall enough for the fade to be a fade; below this it reads as a grey stripe. */
 private val JumpBandHeight = 96.dp
 
-/**
- * Smaller than Home's 96dp status glyph, which is the subject of its screen;
- * this one only marks the sentence that carries the meaning.
- */
 private val EmptyIconSize = 64.dp
 
-/**
- * How far from an end counts as already there — roughly a screen, since a
- * reader two lines from an edge needs no offer to move two lines, and a
- * threshold tripping on the last item alone would flicker as it scrolled.
- *
- * Shared by both bands, so a long log far from both ends shows both. From the
- * middle of a thousand entries, both ends really are somewhere else.
- */
 private const val JumpThreshold = 8
 
-/**
- * The log as read from disk, with a way to read it again. File I/O — at the cap
- * this parses a megabyte across two files — so it stays off the composition
- * thread.
- *
- * Not observed for changes: entries arrive while a session runs, and a list
- * reordering itself under a finger would be worse than one current as of
- * opening it. [reload] covers the one case where the screen knows the file
- * changed because it changed it.
- *
- * @param isLoaded whether the read has finished, distinct from an empty list —
- *   which is also what the first frame holds.
- */
 @Immutable
 data class LogEntries(
     val entries: List<LogEntry>,
@@ -108,10 +75,6 @@ data class LogEntries(
     val reload: () -> Unit,
 )
 
-/**
- * Grouped so [LogPage] stays inside the parameter limit. [onClear] hands back
- * what it could not empty, so the screen cannot claim a half-achieved clear.
- */
 @Immutable
 data class LogActions(
     val onClear: (onCleared: (String?) -> Unit) -> Unit,
@@ -125,8 +88,6 @@ fun rememberLogEntries(): LogEntries {
     var entries by remember { mutableStateOf(emptyList<LogEntry>()) }
     var isLoaded by remember { mutableStateOf(false) }
 
-    // A counter rather than a flag, so a second clear while the first is still
-    // reading is still a distinct key.
     var generation by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(generation) {
@@ -134,18 +95,9 @@ fun rememberLogEntries(): LogEntries {
         isLoaded = true
     }
 
-    // A reload does not clear isLoaded: the entries on screen stay valid until
-    // the new read replaces them, and blanking would flash a list about to be
-    // redrawn with nearly the same contents.
     return LogEntries(entries, isLoaded) { generation++ }
 }
 
-/**
- * The session log, both files interleaved by timestamp.
- *
- * Oldest first, unlike `merged()`: a log read top to bottom is a story, and
- * reversing it puts the cause after the effect.
- */
 @Composable
 fun LogPage(
     log: LogEntries,
@@ -178,18 +130,13 @@ fun LogPage(
             title = "Log",
             onBack = actions.onBack,
             action = {
-                // Absent rather than greyed out: both items work on entries,
-                // this screen cannot produce any, and the empty state already
-                // says what to do. Gated on the read landing too, so it does
-                // not appear for a frame before an empty log resolves.
+
                 if (log.isLoaded && entries.isNotEmpty()) {
                     val isAllSelected = selected.size == entries.size
 
                     OverflowMenu(isMarked = selected.isNotEmpty()) {
                         OverflowItem(
-                            // The menu is the only place left to say what Copy
-                            // will take; "COPY" alone beside a selection the
-                            // user made would be ambiguous.
+
                             label = copyLabel(selected.size, entries.size),
                             onClick = {
                                 clipboard.setText(
@@ -199,8 +146,6 @@ fun LogPage(
                             },
                         )
 
-                        // One item that flips rather than two with one always
-                        // inert — the selection already decides which applies.
                         OverflowItem(
                             label = when {
                                 isAllSelected -> "DESELECT ALL"
@@ -223,8 +168,6 @@ fun LogPage(
             },
         )
 
-        // Nothing until the read lands: a glyph-and-button empty state flashing
-        // on the way to a log that was never empty is worse than a blank moment.
         if (!log.isLoaded) return@Column
 
         if (entries.isEmpty()) {
@@ -236,8 +179,6 @@ fun LogPage(
             return@Column
         }
 
-        // One box, so the bands overlay the text rather than taking a strip of
-        // layout from it.
         Box(modifier = Modifier.fillMaxSize()) {
             LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
                 itemsIndexed(entries) { index, entry ->
@@ -273,24 +214,8 @@ fun LogPage(
     }
 }
 
-/** Which end of the list a band offers to travel to. */
 private enum class JumpEdge { TOP, BOTTOM }
 
-/**
- * The way back to either end of the log — a session's start and its outcome,
- * with a long scroll stranding the reader far from both.
- *
- * A gradient rather than a bar, so the label stays legible over whatever text
- * is underneath without drawing a second horizontal edge under the header's.
- * Each fades from transparent toward its own edge.
- *
- * Named in full rather than drawn as a chevron: a bare arrow over a scrolling
- * list could mean the end of the log or one page down.
- *
- * The band never takes touch — it is a full-width mostly-transparent rectangle
- * over the rows that are this screen's selection targets. Only the label is
- * interactive.
- */
 @Composable
 private fun JumpBand(
     edge: JumpEdge,
@@ -302,14 +227,11 @@ private fun JumpBand(
     val colors = ShizziTheme.colors
     val isTop = edge == JumpEdge.TOP
 
-    // derivedStateOf so recomposition keys on the comparison, not the scroll
-    // position: this reads a value that changes every frame of a fling to
-    // answer a question whose answer changes twice.
     val isShowing by remember(count, edge) {
         derivedStateOf {
             val visible = listState.layoutInfo.visibleItemsInfo
             val distance = when {
-                // Distance from the nearest visible row to this band's end.
+
                 isTop -> visible.firstOrNull()?.index ?: 0
                 else -> count - 1 - (visible.lastOrNull()?.index ?: 0)
             }
@@ -325,9 +247,7 @@ private fun JumpBand(
         exit = fadeOut(),
         modifier = modifier,
     ) {
-        // The container paints and the label is its only child, so the band is
-        // paint and nothing else — a clickable here would put a full-width
-        // touch target over the rows.
+
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -337,22 +257,19 @@ private fun JumpBand(
                 ),
             contentAlignment = if (isTop) Alignment.TopCenter else Alignment.BottomCenter,
         ) {
-            // Bare text: a bordered box here would outrank the header's while
-            // doing less.
+
             Text(
                 text = if (isTop) "SCROLL TO TOP" else "SCROLL TO BOTTOM",
                 style = ShizziTheme.typography.label,
                 color = colors.onSurface,
                 modifier = Modifier
-                    // Outside the clickable: clearance from the screen edge,
-                    // not part of the target.
+
                     .padding(
                         top = if (isTop) ShizziTheme.spacing.lg else 0.dp,
                         bottom = if (isTop) 0.dp else ShizziTheme.spacing.lg,
                     )
                     .clickable {
-                        // Animated: a teleport gives no sense of how much was
-                        // skipped, on a screen people scroll back through.
+
                         scope.launch {
                             listState.animateScrollToItem(if (isTop) 0 else count - 1)
                         }
@@ -363,10 +280,6 @@ private fun JumpBand(
     }
 }
 
-/**
- * The row is the selection unit: character-level drag selection is a lot of
- * machinery and awkward under a finger, and a log is quoted by the line anyway.
- */
 @Composable
 private fun LogRow(
     number: Int,
@@ -383,8 +296,7 @@ private fun LogRow(
                 if (isSelected) colors.primary.copy(alpha = SelectionTint) else colors.background,
             )
             .clickable(onClick = onToggle)
-            // Drawn, not composed: the rule runs the full height of a wrapped
-            // row, which a Divider between two columns would not.
+
             .drawBehind {
                 val rule = GutterWidth.toPx()
                 drawLine(
@@ -417,10 +329,6 @@ private fun LogRow(
     }
 }
 
-/**
- * The level is bold rather than coloured: the palette spends its one accent on
- * actionable state, and the level word already says which it is.
- */
 @Composable
 private fun LogText(entry: LogEntry, modifier: Modifier = Modifier) {
     val colors = ShizziTheme.colors
@@ -428,8 +336,7 @@ private fun LogText(entry: LogEntry, modifier: Modifier = Modifier) {
 
     Text(
         text = buildString {
-            // Dropped here but kept in a copy: on screen the date is the same
-            // for every visible row, and the level gets its own weight.
+
             append(entry.timestamp.substringAfter(' ').ifEmpty { entry.timestamp })
             if (isNotEmpty()) append("  ")
             append(entry.message)
@@ -442,14 +349,6 @@ private fun LogText(entry: LogEntry, modifier: Modifier = Modifier) {
     )
 }
 
-/**
- * Two different situations. Usually no session has run yet, and the way out is
- * to run one — but the screen reads the same with logging switched off, where
- * that message would be a lie, since a session would produce nothing either.
- *
- * The logging CTA toggles in place rather than opening Settings: a button that
- * only leads to the real button is a detour dressed as an action.
- */
 @Composable
 private fun EmptyLog(
     isLogging: Boolean,
@@ -476,8 +375,6 @@ private fun EmptyLog(
             color = ShizziTheme.colors.onSurface,
         )
 
-        // Only the waiting state gets a second line: "Logging is disabled" is
-        // the whole fact, and the action below says what to do about it.
         if (isLogging) {
             Spacer(Modifier.height(ShizziTheme.spacing.sm))
 
@@ -489,8 +386,6 @@ private fun EmptyLog(
             )
         }
 
-        // Smaller than the gap above the title: the action's own 48dp target
-        // already holds most of the separation.
         Spacer(Modifier.height(ShizziTheme.spacing.sm))
 
         EmptyAction(
@@ -500,17 +395,10 @@ private fun EmptyLog(
     }
 }
 
-/**
- * Bare text, like CANCEL on Home — not a filled box. The accent belongs to the
- * connect button, and a filled one here would claim to be the same order of
- * thing while two screens away from it. Turquoise text keeps it findable
- * without competing.
- */
 @Composable
 private fun EmptyAction(label: String, onClick: () -> Unit) {
     Box(
-        // Sized to the touch minimum rather than to the text, which is shorter
-        // than a finger.
+
         modifier = Modifier
             .height(MinTouchTarget)
             .clickable(onClick = onClick),
@@ -524,24 +412,12 @@ private fun EmptyAction(label: String, onClick: () -> Unit) {
     }
 }
 
-/**
- * Keyed on what lands on the clipboard, not on the selection: nothing selected
- * and everything selected both copy the whole log, so both say ALL.
- *
- * A count appears only for a genuine subset, and names its unit so a bare
- * number is not read as characters. Singular at one — the case comes up
- * constantly with per-row selection.
- */
 private fun copyLabel(count: Int, total: Int): String = when {
     count == 0 || count == total -> "COPY ALL"
     count == 1 -> "COPY 1 LINE"
     else -> "COPY $count LINES"
 }
 
-/**
- * Full timestamps, no line numbers: the numbers are a reading aid for wrapped
- * entries, so pasting them would paste this screen's layout, not the log.
- */
 private fun copyText(entries: List<LogEntry>, selected: Set<Int>): String = entries
     .filterIndexed { index, _ -> selected.isEmpty() || index in selected }
     .joinToString("\n") { entry ->

--- a/app/src/main/java/dev/shizzi/ui/Navigation.kt
+++ b/app/src/main/java/dev/shizzi/ui/Navigation.kt
@@ -7,14 +7,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 
-/**
- * A stack, not a graph: Home is the root, Settings its child, Log a child of
- * Settings. A navigation library would be a dependency and a graph declaration
- * to express exactly this.
- */
 enum class Screen { HOME, LOG, SETTINGS }
 
-/** By name rather than Parcelable, which means a plugin to serialise an enum. */
 private val ScreenSaver = Saver<MutableState<Screen>, String>(
     save = { it.value.name },
     restore = { name ->
@@ -22,12 +16,10 @@ private val ScreenSaver = Saver<MutableState<Screen>, String>(
     },
 )
 
-/** Saveable so a rotation while reading the log does not return to Home. */
 @Composable
 fun rememberNavigator(): MutableState<Screen> =
     rememberSaveable(saver = ScreenSaver) { mutableStateOf(Screen.HOME) }
 
-/** Disabled on Home, so back leaves the app rather than being swallowed. */
 @Composable
 fun HandleBack(current: Screen, onBack: () -> Unit) {
     BackHandler(enabled = current != Screen.HOME, onBack = onBack)

--- a/app/src/main/java/dev/shizzi/ui/OpenUrl.kt
+++ b/app/src/main/java/dev/shizzi/ui/OpenUrl.kt
@@ -6,10 +6,6 @@ import android.content.Intent
 import android.net.Uri
 import dev.shizzi.SessionLog
 
-/**
- * A device with no browser is unusual but not impossible, and an unhandled
- * ActivityNotFoundException would crash the app over a link to a homepage.
- */
 fun Context.openUrl(url: String) {
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/java/dev/shizzi/ui/OverflowMenu.kt
+++ b/app/src/main/java/dev/shizzi/ui/OverflowMenu.kt
@@ -24,33 +24,14 @@ import dev.shizzi.ui.theme.ShadowOffset
 import dev.shizzi.ui.theme.ShizziTheme
 import dev.shizzi.ui.theme.brutalSurface
 
-/** A minimum, not a fixed width: clipping a label would be worse than growing. */
 private val MenuMinWidth = 180.dp
 
-/**
- * Lifts the menu clear of the header rule. Material anchors flush to the
- * button, putting the menu's top border a few pixels from the header's line —
- * two parallel edges that read as a rendering fault.
- */
 private val MenuOffset = DpOffset(x = 0.dp, y = 4.dp)
 
-/** Material's menu defaults to 4dp rounded; nothing else here has a corner. */
 private val SquareShape = RectangleShape
 
-/** What an unavailable control fades to, matching the settings screen. */
 private const val DisabledAlpha = 0.4f
 
-/**
- * The header's overflow menu.
- *
- * Material's [DropdownMenu] for its dismiss and placement behaviour — outside
- * taps, back press, staying on screen near an edge — with its surface switched
- * off, since a rounded elevated card would look imported from another app.
- *
- * Has no disabled state: a menu with nothing worth opening should not be on
- * screen, and greying it out spends the one spot a screen has for saying
- * something useful on a control that explains nothing. Callers omit it.
- */
 @Composable
 fun OverflowMenu(
     isMarked: Boolean = false,
@@ -65,14 +46,10 @@ fun OverflowMenu(
             icon = Icons.Filled.MoreVert,
             contentDescription = "More options",
             onClick = { isOpen = true },
-            // A menu hides its contents, so state that was legible in the
-            // header — a live selection — needs to show through the button.
+
             tint = if (isMarked) colors.primary else colors.onSurface,
         )
 
-        // Nothing but a positioned, dismissable container; the look comes from
-        // the brutalSurface inside, the same call every other bordered element
-        // makes rather than a stroke reimplemented here that would drift.
         DropdownMenu(
             expanded = isOpen,
             onDismissRequest = { isOpen = false },
@@ -84,9 +61,7 @@ fun OverflowMenu(
             border = null,
         ) {
             Box(
-                // Room for the shadow to land in: the popup sizes itself to
-                // this content, so without the padding the offset shadow falls
-                // outside the window and is clipped, leaving a plain box.
+
                 modifier = Modifier.padding(end = ShadowOffset, bottom = ShadowOffset),
             ) {
                 Column(
@@ -101,18 +76,8 @@ fun OverflowMenu(
     }
 }
 
-/**
- * Receiver for a menu's contents, so an item can close the menu without every
- * call site threading a dismiss lambda through its own click handler.
- */
 class OverflowScope internal constructor(internal val dismiss: () -> Unit)
 
-/**
- * Left-aligned mono like the settings rows, not a Material menu item.
- *
- * Closes before acting: every action here finishes immediately and leaves
- * nothing to look at, so holding the menu open only costs a second tap.
- */
 @Composable
 fun OverflowScope.OverflowItem(
     label: String,

--- a/app/src/main/java/dev/shizzi/ui/ScreenHeader.kt
+++ b/app/src/main/java/dev/shizzi/ui/ScreenHeader.kt
@@ -17,19 +17,8 @@ import androidx.compose.ui.unit.dp
 import dev.shizzi.ui.theme.HeaderHeight
 import dev.shizzi.ui.theme.ShizziTheme
 
-/**
- * 1dp rather than Dp.Hairline, which is one physical pixel — a third of the
- * thinnest line elsewhere on a ~3x screen, reading as an artefact beside 2dp
- * borders.
- */
 private val HeaderRule = 1.dp
 
-/**
- * Back button, left-aligned title, optional action on the right edge.
- *
- * Home does not use this: it has a badge where the title would be, no back
- * button, and content centred in open space that a rule would divide nothing of.
- */
 @Composable
 fun ScreenHeader(
     title: String,
@@ -42,8 +31,7 @@ fun ScreenHeader(
         modifier = Modifier
             .fillMaxWidth()
             .height(HeaderHeight)
-            // Before the horizontal padding, so the rule runs edge to edge
-            // rather than reading as an underline on the title.
+
             .drawBehind {
                 val thickness = HeaderRule.toPx()
                 drawLine(

--- a/app/src/main/java/dev/shizzi/ui/SessionToasts.kt
+++ b/app/src/main/java/dev/shizzi/ui/SessionToasts.kt
@@ -5,14 +5,6 @@ import androidx.compose.runtime.LaunchedEffect
 import dev.shizzi.ShizukuState
 import dev.shizzi.SessionUiState
 
-/**
- * Turns state into toasts, in one place: all three screens float the same host,
- * and "what deserves a message" is worth reading together rather than inferring
- * from scattered call sites.
- *
- * Only two things are announced — a session failure, and a Shizuku problem the
- * user can act on. Success is already in the status icon and the button label.
- */
 @Composable
 fun SessionToasts(
     state: SessionUiState,
@@ -23,10 +15,6 @@ fun SessionToasts(
     ShizukuToast(state.shizukuState, toasts, onRequestPermission)
 }
 
-/**
- * Indefinite: an unread error should not time out while the user is looking
- * away from the phone they just tried to tether from.
- */
 @Composable
 private fun ErrorToast(lastError: String, toasts: ToastState) {
     LaunchedEffect(lastError) {
@@ -45,12 +33,6 @@ private fun ErrorToast(lastError: String, toasts: ToastState) {
     }
 }
 
-/**
- * The badge in the header says Shizuku is unavailable; this says what to do.
- *
- * Only the permission case carries an action, because it is the only one the
- * app can resolve — installing or starting Shizuku happens outside it.
- */
 @Composable
 private fun ShizukuToast(
     state: ShizukuState,
@@ -76,7 +58,6 @@ private fun ShizukuToast(
     }
 }
 
-/** Phrased as the user's situation rather than the API's return value. */
 private fun describe(state: ShizukuState): String = when (state) {
     is ShizukuState.NotInstalled -> "Shizuku is not installed"
     is ShizukuState.NotRunning -> "Shizuku is installed but not running"

--- a/app/src/main/java/dev/shizzi/ui/SettingsPage.kt
+++ b/app/src/main/java/dev/shizzi/ui/SettingsPage.kt
@@ -23,14 +23,8 @@ private const val SOURCE_URL = "https://github.com/carlelieser/shizzi"
 private const val ISSUE_URL = "https://github.com/carlelieser/shizzi/issues/new"
 private const val AUTHOR_URL = "https://carlelieser.dev"
 
-/**
- * Enough to read as unavailable, not so far the user loses their place — the
- * run's toast sits over this, and a page faded to nothing would make it look
- * like a dialog on an empty screen.
- */
 private const val BusyAlpha = 0.4f
 
-/** Grouped so the page takes state rather than four values. */
 data class SettingsState(
     val shizuku: ShizukuState,
     val theme: ThemeChoice,
@@ -38,7 +32,6 @@ data class SettingsState(
     val isRunningDiagnostics: Boolean,
 )
 
-/** Likewise, so the page stays within the parameter limit. */
 data class SettingsActions(
     val onSetTheme: (ThemeChoice) -> Unit,
     val onSetLogging: (Boolean) -> Unit,
@@ -48,10 +41,6 @@ data class SettingsActions(
     val onRestartOnboarding: () -> Unit,
 )
 
-/**
- * Everything configurable, plus the Shizuku detail the home badge cannot hold.
- * Scrolls, since four sections already exceed a short screen.
- */
 @Composable
 fun SettingsPage(
     state: SettingsState,
@@ -61,8 +50,7 @@ fun SettingsPage(
     val isBusy = state.isRunningDiagnostics
 
     Column(modifier = Modifier.fillMaxSize().systemBarsPadding()) {
-        // Outside the dimmed region: a run lasts as long as upstream selection
-        // takes to settle, and the ViewModel owns it, so leaving is free.
+
         ScreenHeader(title = "Settings", onBack = onBack)
 
         Column(
@@ -84,20 +72,11 @@ fun SettingsPage(
             SectionLabel("About")
             AboutSection()
 
-            // The last row would otherwise sit against the navigation bar.
             Spacer(Modifier.height(ShizziTheme.spacing.xxl))
         }
     }
 }
 
-/**
- * Swallows every pointer event over this subtree while [isBusy].
- *
- * At the boundary rather than an `isEnabled` per row: this screen has three
- * kinds of control, and disabling them individually means every future row has
- * to remember to opt in. Consumed in the initial pass, so events never reach
- * the children at all.
- */
 private fun Modifier.inert(isBusy: Boolean): Modifier = when {
     !isBusy -> this
     else -> this.pointerInput(Unit) {
@@ -111,10 +90,6 @@ private fun Modifier.inert(isBusy: Boolean): Modifier = when {
     }
 }
 
-/**
- * Titles only: these name things a developer already knows, so a description
- * under each just restated the title at greater length.
- */
 @Composable
 private fun DeveloperSection(isLogging: Boolean, actions: SettingsActions) {
     SettingsToggle(
@@ -123,7 +98,6 @@ private fun DeveloperSection(isLogging: Boolean, actions: SettingsActions) {
         onCheckedChange = actions.onSetLogging,
     )
 
-    // Under the toggle that decides whether it records anything.
     SettingsAction(
         label = SettingsText(title = "View logs"),
         onClick = actions.onOpenLog,
@@ -134,22 +108,12 @@ private fun DeveloperSection(isLogging: Boolean, actions: SettingsActions) {
         onClick = actions.onRunProbes,
     )
 
-    // Navigates rather than resetting anything else: the wizard reads the same
-    // Shizuku state and re-runs its own check, so there is nothing to clear
-    // beyond the flag that decides which tree renders.
     SettingsAction(
         label = SettingsText(title = "Restart onboarding"),
         onClick = actions.onRestartOnboarding,
     )
 }
 
-/**
- * Opened from the context rather than a callback threaded from the ViewModel:
- * no state changes, so routing it upward adds a hop that forwards an intent.
- *
- * Only Author keeps a subtitle, where it names the destination rather than
- * restating what the title and the external-link glyph already carry.
- */
 @Composable
 private fun AboutSection() {
     val context = LocalContext.current

--- a/app/src/main/java/dev/shizzi/ui/SettingsRows.kt
+++ b/app/src/main/java/dev/shizzi/ui/SettingsRows.kt
@@ -23,23 +23,12 @@ import androidx.compose.ui.unit.dp
 import dev.shizzi.ui.theme.ShizziTheme
 import dev.shizzi.ui.theme.Spacing
 
-/** Trailing glyph size, smaller than a header icon since it only marks a row. */
 private val RowIconSize = 20.dp
 
-/** Vertical padding shared by every settings row. */
 private val RowPadding = Spacing.md
 
-/**
- * Roughly a single-line label's, so the toggle row matches the text rows.
- * requiredHeight overrides the incoming constraint rather than negotiating
- * within it, which is what lets the control draw larger than it occupies.
- */
 private val SwitchLayoutHeight = 24.dp
 
-/**
- * `subheading` rather than `label` so the name outranks its own description —
- * the two were 13sp over 14sp, which inverted the hierarchy.
- */
 @Composable
 fun SettingsLabel(title: String, subtitle: String, modifier: Modifier = Modifier) {
     Column(
@@ -62,10 +51,6 @@ fun SettingsLabel(title: String, subtitle: String, modifier: Modifier = Modifier
     }
 }
 
-/**
- * The break is carried by the gap and the change of register rather than a
- * rule, which would put a second horizontal line under the header's.
- */
 @Composable
 fun SectionLabel(text: String) {
     Text(
@@ -79,15 +64,6 @@ fun SectionLabel(text: String) {
     )
 }
 
-/**
- * The switch is 48dp tall against a title's ~22dp, so a row centred on it takes
- * its height from the control and puts ~13dp of air around the label that the
- * text-only rows do not have. The row is padded to match [SettingsAction] and
- * the switch overhangs it instead, keeping the section on one rhythm.
- *
- * Invisible while the rows carried subtitles, where a two-line label came close
- * enough to the switch's height to hide the difference.
- */
 @Composable
 fun SettingsToggle(
     label: SettingsText,
@@ -104,8 +80,6 @@ fun SettingsToggle(
             modifier = Modifier.weight(1f),
         )
 
-        // Laid out at the label's height, still drawing and taking touch at its
-        // natural 48dp.
         Switch(
             checked = isChecked,
             onCheckedChange = onCheckedChange,
@@ -119,13 +93,6 @@ fun SettingsToggle(
     }
 }
 
-/**
- * The trailing glyph says where the tap goes — onward within the app, or out of
- * the corner and outside it — which is worth knowing before the browser opens.
- *
- * The outward arrow is not auto-mirrored: it means "leaves the app" rather than
- * a direction of travel, and flipping it in an RTL locale would lose that.
- */
 @Composable
 fun SettingsAction(
     label: SettingsText,
@@ -165,5 +132,4 @@ private fun TrailingIcon(icon: ImageVector) {
     )
 }
 
-/** Grouped so a row stays inside the parameter limit with a control and a callback. */
 data class SettingsText(val title: String, val subtitle: String = "")

--- a/app/src/main/java/dev/shizzi/ui/Shimmer.kt
+++ b/app/src/main/java/dev/shizzi/ui/Shimmer.kt
@@ -17,26 +17,6 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import dev.shizzi.ui.theme.ShizziTheme
 
-/**
- * Sweeps a highlight across the glyph while [isActive]. A pulse would read as a
- * heartbeat — a rate the user is invited to judge — where a sweep has direction
- * and no rate to read into.
- *
- * SrcATop, not SrcIn: both clip to the glyph's pixels, but SrcIn *replaces* the
- * destination, so the transparent ends of the sweep erase the icon and it
- * appears to be eaten as the band travels.
- *
- * Inactive returns the receiver untouched, leaving no animation running behind
- * an idle screen.
- *
- * Shared rather than private to one screen: the home status glyph and the
- * welcome mark are the same icon given the same treatment, and a second copy
- * would drift in band width or duration against the first.
- *
- * @param highlight what the band is made of; defaults to the page's ink. The
- *   band has to contrast with the *glyph* it crosses, not with the page, so a
- *   coloured mark needs a lighter sweep than a muted one.
- */
 fun Modifier.shimmer(
     isActive: Boolean,
     highlight: Color? = null,
@@ -52,9 +32,7 @@ fun Modifier.shimmer(
         ),
         label = "shimmerSweep",
     )
-    // Defaults to the page's own ink, which reads as a glint over the muted
-    // home glyph. A caller sweeping a saturated mark passes its own, since
-    // onSurface over turquoise is a dark smear rather than a highlight.
+
     val sweep = highlight ?: ShizziTheme.colors.onSurface
 
     this
@@ -62,9 +40,6 @@ fun Modifier.shimmer(
         .drawWithContent {
             drawContent()
 
-            // Off one edge to off the other, so the band enters and leaves
-            // rather than appearing mid-glyph. Narrower than the glyph, so it
-            // reads as a glint crossing rather than the icon brightening.
             val band = size.width * 0.6f
             val head = progress * (size.width + band * 2f) - band
 

--- a/app/src/main/java/dev/shizzi/ui/ShizukuCard.kt
+++ b/app/src/main/java/dev/shizzi/ui/ShizukuCard.kt
@@ -17,11 +17,6 @@ import dev.shizzi.ShizukuState
 import dev.shizzi.ui.theme.ShizziTheme
 import dev.shizzi.ui.theme.brutalSurface
 
-/**
- * A card rather than a row: this is what a user opens Settings to check when a
- * session will not start, and the version matters in particular — 13.5.4 on
- * Android 16 crashes within minutes.
- */
 @Composable
 fun ShizukuCard(state: ShizukuState, onGrant: () -> Unit) {
     Column(
@@ -41,10 +36,6 @@ fun ShizukuCard(state: ShizukuState, onGrant: () -> Unit) {
     }
 }
 
-/**
- * The value takes the remaining width so a long version string wraps in its own
- * column instead of pushing the name off the row.
- */
 @Composable
 private fun StatusRow(name: String, value: String) {
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
@@ -64,10 +55,6 @@ private fun StatusRow(name: String, value: String) {
     }
 }
 
-/**
- * Offered only when permission is what stands in the way. R1.3 forbids
- * requesting on launch, so this is the explicit action that triggers it.
- */
 @Composable
 private fun GrantButton(onGrant: () -> Unit) {
     Box(
@@ -94,11 +81,6 @@ private fun statusText(state: ShizukuState): String = when (state) {
     ShizukuState.PermissionRequired -> "Permission required"
 }
 
-/**
- * What the privileged service runs as, known only once it is Ready. A dash
- * rather than a hidden row, which would change the card's height and read as
- * information it is not.
- */
 private fun serviceText(state: ShizukuState): String = when (state) {
     is ShizukuState.Ready -> ShizukuGate.shortUid(state.uid)
     else -> "—"

--- a/app/src/main/java/dev/shizzi/ui/StatusIcon.kt
+++ b/app/src/main/java/dev/shizzi/ui/StatusIcon.kt
@@ -18,16 +18,8 @@ import dev.shizzi.UiStatus
 import dev.shizzi.ui.theme.ShizziTheme
 import dev.shizzi.ui.theme.brutalSurface
 
-/** Matches the welcome mark, so the same glyph is the same size across the app. */
 private val StatusIconSize = 280.dp
 
-/**
- * No label under it: the button already reads START or STOP, and a word between
- * the two would state the same fact a third time.
- *
- * Turquoise only when connected, so the screen has exactly one saturated
- * element at a time and it always means the tunnel is up.
- */
 @Composable
 fun StatusIcon(status: UiStatus) {
     val isConnected = status == UiStatus.CONNECTED
@@ -47,11 +39,6 @@ fun StatusIcon(status: UiStatus) {
     )
 }
 
-/**
- * One family throughout, so the glyph reads as one object changing rather than
- * four pictures. Ready and loading share a mark — the shimmer distinguishes
- * them, and swapping glyphs mid-animation would read as a transition.
- */
 private fun glyphFor(status: UiStatus): ImageVector = when (status) {
     UiStatus.READY -> Icons.Filled.WifiTethering
     UiStatus.LOADING -> Icons.Filled.WifiTethering
@@ -59,7 +46,6 @@ private fun glyphFor(status: UiStatus): ImageVector = when (status) {
     UiStatus.ERROR -> Icons.Filled.WifiTetheringError
 }
 
-/** The label the icon does not draw, for anyone using a screen reader. */
 private fun descriptionFor(status: UiStatus): String = when (status) {
     UiStatus.READY -> "Not connected"
     UiStatus.LOADING -> "Connecting"
@@ -67,10 +53,6 @@ private fun descriptionFor(status: UiStatus): String = when (status) {
     UiStatus.ERROR -> "Failed"
 }
 
-/**
- * Absent when Shizuku is ready: a badge confirming the expected is noise on
- * every launch. What to do about a problem is the toast's job.
- */
 @Composable
 fun ShizukuBadge(state: ShizukuState) {
     val text = badgeText(state) ?: return

--- a/app/src/main/java/dev/shizzi/ui/StatusRow.kt
+++ b/app/src/main/java/dev/shizzi/ui/StatusRow.kt
@@ -30,18 +30,9 @@ import dev.shizzi.UiStatus
 import dev.shizzi.ui.theme.ScreenPadding
 import dev.shizzi.ui.theme.ShizziTheme
 
-/** The rule between segments, sized to the caption text beside it. */
 private val DividerWidth = 1.dp
 private val DividerHeight = 12.dp
 
-/**
- * The bottom-edge status line: what the session is, then the build.
- *
- * Only the state takes full contrast, so the eye lands on the one word that
- * changes without the row competing with the button. Always present, unlike the
- * detail it replaced, which hid whenever it had nothing to say and took the
- * version with it.
- */
 @Composable
 fun StatusRow(state: SessionUiState, modifier: Modifier = Modifier) {
     Row(
@@ -51,7 +42,6 @@ fun StatusRow(state: SessionUiState, modifier: Modifier = Modifier) {
     ) {
         StatusLabel(statusWord(state.status))
 
-        // Only while a session is up, or it claims one that ended.
         if (state.status == UiStatus.CONNECTED && state.interfaceName.isNotEmpty()) {
             StatusDivider()
             TunnelSegment(state.interfaceName)
@@ -72,11 +62,6 @@ private fun StatusText(text: String) {
     )
 }
 
-/**
- * One Text rather than two composables: the caption carries letter-spacing, so
- * splitting them puts the trailing track between the words and opens a gap
- * wider than the space it should be.
- */
 @Composable
 private fun StatusLabel(status: String) {
     val colors = ShizziTheme.colors
@@ -96,23 +81,11 @@ private fun StatusLabel(status: String) {
     )
 }
 
-/**
- * A phrase by default, the real name a tap away.
- *
- * The framework assigns the name — TestNetworkService hardcodes a "testtun"
- * prefix and a counter, and no createTunInterface overload accepts one — so it
- * cannot be made friendlier at the source, and it means nothing to anyone not
- * reading Android internals. It stays reachable because it is the string that
- * matches `dumpsys tethering`, which is what someone filing a bug needs.
- */
 @Composable
 private fun TunnelSegment(name: String) {
-    // Keyed on the interface, so a new session starts at the phrase rather than
-    // inheriting the last one's expanded state.
+
     var isShowingName by remember(name) { mutableStateOf(false) }
 
-    // No ripple or press colour: in a row of muted captions, an indication here
-    // would be the loudest thing on an idle screen.
     val interaction = remember { MutableInteractionSource() }
 
     Text(
@@ -129,10 +102,6 @@ private fun TunnelSegment(name: String) {
     )
 }
 
-/**
- * Drawn rather than a "|" character, which carries the font's own spacing and
- * sits off-centre against uppercase caption text.
- */
 @Composable
 private fun StatusDivider() {
     Box(
@@ -144,10 +113,6 @@ private fun StatusDivider() {
     )
 }
 
-/**
- * Not the session's `detail`, which carries things like the raw interface name
- * — true, and not a status. An error's text belongs to the toast.
- */
 private fun statusWord(status: UiStatus): String = when (status) {
     UiStatus.READY -> "Ready"
     UiStatus.LOADING -> "Starting"

--- a/app/src/main/java/dev/shizzi/ui/ThemePicker.kt
+++ b/app/src/main/java/dev/shizzi/ui/ThemePicker.kt
@@ -25,41 +25,22 @@ import dev.shizzi.ui.theme.ThemeChoice
 import dev.shizzi.ui.theme.brutalSurface
 import dev.shizzi.ui.theme.isPressed
 
-/** Tall enough to take a finger, shorter than the connect button. */
 private val OptionHeight = 44.dp
 
-/** Sized like a settings row's trailing glyph rather than a header icon. */
 private val OptionIconSize = 20.dp
 
-/**
- * Sun, moon, and both at once for the one that follows the device —
- * Brightness4 is a rayed sun with a crescent cut into it, which reads as
- * "either, depending" and keeps the three in one visual family.
- *
- * Not BrightnessAuto or SettingsBrightness, which read as automatic
- * *brightness* — a different setting that also exists on the device.
- */
 private fun glyphFor(choice: ThemeChoice): ImageVector = when (choice) {
     ThemeChoice.SYSTEM -> Icons.Filled.Brightness4
     ThemeChoice.LIGHT -> Icons.Filled.LightMode
     ThemeChoice.DARK -> Icons.Filled.DarkMode
 }
 
-/**
- * Written out rather than derived from the enum name: with the text gone this
- * is the only thing naming the option, so it is copy, not a debug string that
- * happens to be readable.
- */
 private fun labelFor(choice: ThemeChoice): String = when (choice) {
     ThemeChoice.SYSTEM -> "Match system"
     ThemeChoice.LIGHT -> "Light"
     ThemeChoice.DARK -> "Dark"
 }
 
-/**
- * Not a radio group: this design has no unfilled-circle vocabulary, and a
- * filled box is already how the app says "this one is active".
- */
 @Composable
 fun ThemePicker(selected: ThemeChoice, onSelect: (ThemeChoice) -> Unit) {
     Row(
@@ -101,7 +82,7 @@ private fun ThemeOption(
             ),
         contentAlignment = Alignment.Center,
     ) {
-        // With the glyph replacing the word, this is all a screen reader has.
+
         Icon(
             imageVector = glyphFor(choice),
             contentDescription = labelFor(choice),

--- a/app/src/main/java/dev/shizzi/ui/Toast.kt
+++ b/app/src/main/java/dev/shizzi/ui/Toast.kt
@@ -7,33 +7,17 @@ import androidx.compose.runtime.remember
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-/** How long a toast stays up. Indefinite ones are dismissed by hand or replaced. */
 @Immutable
 sealed interface ToastDuration {
     data class Timed(val duration: Duration) : ToastDuration
     data object Indefinite : ToastDuration
 }
 
-/** The default dwell for informational toasts. */
 val ToastShort = ToastDuration.Timed(4.seconds)
 
-/** For a toast the user can act on — a missing permission is worth a GRANT. */
 @Immutable
 data class ToastAction(val label: String, val onClick: () -> Unit)
 
-/**
- * A message on screen.
- *
- * @param key identity for replacement: a repeatedly changing state (session up,
- *   then down, then failed) occupies one slot rather than three.
- * @param detail a muted second line, for specifics a headline should not carry
- *   — a file path, an interface name.
- * @param isBusy draws a leading spinner. Pairs with [ToastDuration.Indefinite],
- *   since work in progress is ended by the work, not a timer.
- * @param onDismiss run however the toast leaves — tapped away, expired, or
- *   replaced by its action. For content owned elsewhere: without it the state
- *   that produced the toast stays set and posts the same stale result again.
- */
 @Immutable
 data class Toast(
     val key: String,
@@ -45,32 +29,22 @@ data class Toast(
     val onDismiss: (() -> Unit)? = null,
 )
 
-/** Keys for toasts that are posted from more than one place. */
 object ToastKeys {
-    /** Session lifecycle: starting, connected, stopped, failed. */
+
     const val SESSION = "session"
 
-    /** Shizuku availability and permission. */
     const val SHIZUKU = "shizuku"
 
-    /** A diagnostics run: in progress, then its outcome. */
     const val DIAGNOSTICS = "diagnostics"
 
-    /** Clearing the log: the confirmation, then what it managed to clear. */
     const val CLEAR_LOG = "clear-log"
 }
 
-/**
- * A list rather than one slot: an error and a permission prompt are independent
- * facts, and hiding one behind the other loses information. Keyed replacement
- * is what bounds the list.
- */
 class ToastState {
     private val entries = mutableStateListOf<Toast>()
 
     val toasts: List<Toast> get() = entries
 
-    /** Adds [toast], or replaces the existing one with the same key in place. */
     fun show(toast: Toast) {
         val existing = entries.indexOfFirst { it.key == toast.key }
         if (existing >= 0) entries[existing] = toast else entries.add(toast)

--- a/app/src/main/java/dev/shizzi/ui/ToastHost.kt
+++ b/app/src/main/java/dev/shizzi/ui/ToastHost.kt
@@ -40,27 +40,12 @@ import kotlinx.coroutines.launch
 import androidx.compose.material3.Text
 import kotlin.math.abs
 
-/** Matches the cap height of the message beside it, so the row reads as one line. */
 private val SpinnerSize = 18.dp
 
-/** Thin enough not to read as a second bordered element inside the toast. */
 private val SpinnerStroke = 2.dp
 
-/**
- * A fraction of the toast's width, so the gesture asks the same proportion on
- * any screen. Low enough for a flick, high enough that a thumb brushing
- * sideways during a tap does not.
- */
 private const val DismissFraction = 0.35f
 
-/**
- * Bottom-anchored and stacked upward, so the newest sits closest to the thumb
- * and older ones rise out of the way rather than shifting it under a finger
- * already moving toward it.
- *
- * Overlay this in a Box rather than nesting content: toasts float over the
- * screen and must not join its layout.
- */
 @Composable
 fun ToastHost(state: ToastState, modifier: Modifier = Modifier) {
     Column(
@@ -69,7 +54,7 @@ fun ToastHost(state: ToastState, modifier: Modifier = Modifier) {
             .padding(ScreenPadding),
         verticalArrangement = Arrangement.spacedBy(ShizziTheme.spacing.sm),
     ) {
-        // Reversed so the newest is drawn last, at the bottom of the column.
+
         state.toasts.asReversed().forEach { toast ->
             ToastRow(
                 toast = toast,
@@ -82,10 +67,6 @@ fun ToastHost(state: ToastState, modifier: Modifier = Modifier) {
     }
 }
 
-/**
- * The timer is keyed on the message as well as the key, so a replacement gets
- * a full dwell rather than inheriting what was left of the message it replaced.
- */
 @Composable
 private fun ToastRow(toast: Toast, onExpire: () -> Unit) {
     val duration = toast.duration
@@ -109,30 +90,14 @@ private fun ToastRow(toast: Toast, onExpire: () -> Unit) {
     }
 }
 
-/**
- * Drags sideways, dismissing past [DismissFraction].
- *
- * Not SwipeToDismissBox: that frames the gesture as revealing a background and
- * wraps the content in its own layout to draw it, so for a toast — nothing
- * behind it, and an offset shadow of its own to keep — the machinery would all
- * be spent being suppressed.
- *
- * Fades with distance so a partial drag shows the dismissal coming, and springs
- * back short of the threshold, which is what makes the fade read as progress.
- * Disabled while busy, matching the tap.
- */
 private fun Modifier.swipeToDismiss(
     isEnabled: Boolean,
     onDismiss: () -> Unit,
 ): Modifier = composed {
-    // Every remember runs before the enabled check: a `composed` body is a
-    // composable, so returning early past them would change the slot table's
-    // shape when a toast goes from busy to finished.
+
     val offset = remember { Animatable(0f) }
     val scope = rememberCoroutineScope()
 
-    // The handler is keyed on `isEnabled` alone, so without this it would
-    // capture the callback from the composition that installed it.
     val dismiss by rememberUpdatedState(onDismiss)
 
     var width by remember { mutableIntStateOf(0) }
@@ -143,7 +108,7 @@ private fun Modifier.swipeToDismiss(
         .onSizeChanged { width = it.width }
         .graphicsLayer {
             translationX = offset.value
-            // Fully opaque until the drag is underway, gone at the threshold.
+
             alpha = 1f - (abs(offset.value) / (width * DismissFraction)).coerceIn(0f, 1f)
         }
         .pointerInput(isEnabled) {
@@ -169,8 +134,7 @@ private fun ToastSurface(toast: Toast, onDismiss: () -> Unit, modifier: Modifier
         modifier = modifier
             .fillMaxWidth()
             .brutalSurface(fill = ShizziTheme.colors.surface)
-            // An indefinite toast has no other way out. Not while busy, where
-            // dismissing hides the only sign of work still in flight.
+
             .clickable(enabled = !toast.isBusy, onClick = onDismiss)
             .padding(ShizziTheme.spacing.lg),
         verticalAlignment = Alignment.CenterVertically,
@@ -186,23 +150,13 @@ private fun ToastSurface(toast: Toast, onDismiss: () -> Unit, modifier: Modifier
     }
 }
 
-/**
- * Mono throughout: a toast reports machine facts — an exception, a path, a
- * refusal from the framework — which this app sets in mono everywhere else.
- * `log` rather than `caption`, which is tracked and uppercase wherever it is
- * used and wrong for a path.
- *
- * The two lines separate by weight, not size. A second size in a surface this
- * small reads as two unrelated things stacked.
- */
 @Composable
 private fun ToastText(toast: Toast, modifier: Modifier = Modifier) {
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(ShizziTheme.spacing.xs),
     ) {
-        // W500, the weight a settings row's name carries: message-to-detail is
-        // the same relationship as name-to-description.
+
         Text(
             text = toast.message,
             style = ShizziTheme.typography.log.copy(fontWeight = FontWeight.W500),
@@ -219,13 +173,6 @@ private fun ToastText(toast: Toast, modifier: Modifier = Modifier) {
     }
 }
 
-/**
- * Muted, matching the connect button's spinner: turquoise means a session is
- * up, and a spinner is the wait before anyone knows whether it will be.
- *
- * Indeterminate because a probe sequence has no measurable fraction complete —
- * it waits on upstream selection, which either settles or times out.
- */
 @Composable
 private fun ToastSpinner() {
     CircularProgressIndicator(
@@ -235,13 +182,6 @@ private fun ToastSpinner() {
     )
 }
 
-/**
- * Text, not a second bordered box, which inside a bordered surface would read
- * as a box in a box — so weight carries the affordance instead.
- *
- * Not turquoise: the accent means a session is up, and a toast is already the
- * most prominent thing on screen without also taking the loudest colour.
- */
 @Composable
 private fun ToastActionButton(action: ToastAction, onDismiss: () -> Unit) {
     Text(

--- a/app/src/main/java/dev/shizzi/ui/VpnChip.kt
+++ b/app/src/main/java/dev/shizzi/ui/VpnChip.kt
@@ -12,17 +12,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import dev.shizzi.ui.theme.ShizziTheme
 
-/**
- * Says the tethered clients are going out through a VPN.
- *
- * No surface behind it: every bordered element here is something to press, so
- * that treatment made a label look like a control. The key glyph is what
- * Android itself puts in the status bar for an active VPN.
- *
- * In the accent, against the usual rule, because this is the one thing a user
- * opens the app to confirm — and with no surface to frame it, the colour is
- * what keeps it from reading as a caption.
- */
 @Composable
 fun VpnChip() {
     Row(

--- a/app/src/main/java/dev/shizzi/ui/onboarding/CapabilityCard.kt
+++ b/app/src/main/java/dev/shizzi/ui/onboarding/CapabilityCard.kt
@@ -21,22 +21,12 @@ import dev.shizzi.Capability
 import dev.shizzi.ui.theme.ShizziTheme
 import dev.shizzi.ui.theme.brutalSurface
 
-/** Sized like a settings row's trailing glyph, which is the same job. */
 private val MarkSize = 20.dp
 
-/** Matches the mark, so the row does not change height when the check lands. */
 private val SpinnerSize = 16.dp
 
-/** How one capability's check is going. */
 enum class CapabilityStatus { LOADING, SUCCESS, FAILURE }
 
-/**
- * One capability: what it is, why it matters, and how it went.
- *
- * The description is what the row is for. "Prefer test networks" names a method
- * and tells a user nothing, so each row says what the device would be unable to
- * do without it.
- */
 @Composable
 fun CapabilityCard(capability: Capability, status: CapabilityStatus, detail: String) {
     Row(
@@ -63,9 +53,6 @@ fun CapabilityCard(capability: Capability, status: CapabilityStatus, detail: Str
                 color = ShizziTheme.colors.onSurfaceMuted,
             )
 
-            // Only when it failed: the evidence for a capability that is
-            // present is the app working, and printing it on every row would
-            // bury the one line that matters.
             if (status == CapabilityStatus.FAILURE) {
                 CapabilityDetail(detail)
             }
@@ -75,10 +62,6 @@ fun CapabilityCard(capability: Capability, status: CapabilityStatus, detail: Str
     }
 }
 
-/**
- * The verbatim reason, in the log face — this is a resolution failure quoted
- * from the platform, not copy, and setting it as prose would claim otherwise.
- */
 @Composable
 private fun CapabilityDetail(detail: String) {
     Text(
@@ -89,22 +72,9 @@ private fun CapabilityDetail(detail: String) {
     )
 }
 
-/**
- * Offers a break after each dot in a dotted name.
- *
- * These lines are exception text, whose class and method names carry no spaces
- * — so the layout has no legal break and splits mid-identifier. A zero-width
- * space is a break opportunity that renders as nothing, leaving the text
- * exactly as the platform reported it while letting it wrap where a reader
- * would expect.
- */
 private fun breakableIdentifiers(detail: String): String =
     detail.replace(".", ".\u200B")
 
-/**
- * Reserved at the mark's size in every state, so a row does not resize as its
- * spinner is replaced by a result.
- */
 @Composable
 private fun StatusMark(status: CapabilityStatus) {
     val colors = ShizziTheme.colors
@@ -142,11 +112,6 @@ private fun titleFor(capability: Capability): String = when (capability) {
     Capability.PREFER_TEST_NETWORKS -> "Prefer test networks"
 }
 
-/**
- * What the device would be unable to do, rather than what the API is called.
- * The two are separate capabilities with separate floors — a device can have
- * the first and not the second — so neither description implies the other.
- */
 private fun descriptionFor(capability: Capability): String = when (capability) {
     Capability.TEST_NETWORK ->
         "Lets the app create the test network tunnel your hotspot traffic " +

--- a/app/src/main/java/dev/shizzi/ui/onboarding/CompatibilityStep.kt
+++ b/app/src/main/java/dev/shizzi/ui/onboarding/CompatibilityStep.kt
@@ -18,17 +18,9 @@ import dev.shizzi.CapabilityResult
 import dev.shizzi.CompatibilityState
 import dev.shizzi.ui.theme.ShizziTheme
 
-/**
- * The capabilities, then the verdict they add up to.
- *
- * Scrolls, because a device failing both checks carries two quoted resolution
- * failures and that exceeds a short screen.
- */
 @Composable
 fun CompatibilityStep(state: CompatibilityState) {
-    // Scrolls only when a failure's quoted detail is on screen. Scrolling
-    // always would leave the column unbounded, and the verdict below it could
-    // not take a weight — which is what centres it in the gap above the dots.
+
     val isOverflowing = state is CompatibilityState.Failed
 
     Column(
@@ -56,12 +48,6 @@ fun CompatibilityStep(state: CompatibilityState) {
     }
 }
 
-/**
- * Centres the verdict in whatever is left between the cards and the footer.
- *
- * Falls back to wrapping its content while the column scrolls, where there is
- * no bounded height to take a fraction of.
- */
 @Composable
 private fun ColumnScope.VerdictBand(state: CompatibilityState, isOverflowing: Boolean) {
     val sizing = when {
@@ -77,12 +63,6 @@ private fun ColumnScope.VerdictBand(state: CompatibilityState, isOverflowing: Bo
     }
 }
 
-/**
- * Why the check could not run, under the rows it left unanswered.
- *
- * Distinct from a capability's own detail: this is the app failing to reach the
- * privileged process, so it belongs to the run rather than to either row.
- */
 @Composable
 private fun CheckFailure(problem: String) {
     Text(
@@ -93,10 +73,6 @@ private fun CheckFailure(problem: String) {
     )
 }
 
-/**
- * Idle renders as loading rather than a fourth state: the check starts with the
- * step, so the gap before the first result is the only time this is seen.
- */
 private fun statusFor(state: CompatibilityState, capability: Capability): CapabilityStatus =
     when (state) {
         is CompatibilityState.Complete -> when {
@@ -108,10 +84,6 @@ private fun statusFor(state: CompatibilityState, capability: Capability): Capabi
         else -> CapabilityStatus.LOADING
     }
 
-/**
- * Empty unless the run answered: a failed run's reason is the run's, and
- * repeating it under both rows would state it twice.
- */
 private fun detailFor(state: CompatibilityState, capability: Capability): String = when (state) {
     is CompatibilityState.Complete -> state.resultFor(capability)?.detail.orEmpty()
     else -> ""

--- a/app/src/main/java/dev/shizzi/ui/onboarding/CompatibilityVerdict.kt
+++ b/app/src/main/java/dev/shizzi/ui/onboarding/CompatibilityVerdict.kt
@@ -16,21 +16,12 @@ import dev.shizzi.CompatibilityState
 import dev.shizzi.isCompatible
 import dev.shizzi.ui.theme.ShizziTheme
 
-/** Matches the Shizuku step's mark, so the two verdicts carry equal weight. */
 private val VerdictIconSize = 120.dp
 
-/** Sized under the mark it replaces, so the band does not jump when it lands. */
 private val SpinnerSize = 64.dp
 
 private val SpinnerStroke = 3.dp
 
-/**
- * The verdict, as one mark under the capabilities that justify it.
- *
- * The same three marks the Shizuku step uses, so a verdict reads the same way
- * on both. Unlike that step, the spinner has a state behind it: the check is a
- * round trip to the shell rather than a synchronous read.
- */
 @Composable
 fun CompatibilityVerdict(state: CompatibilityState) {
     val colors = ShizziTheme.colors

--- a/app/src/main/java/dev/shizzi/ui/onboarding/OnboardingFlow.kt
+++ b/app/src/main/java/dev/shizzi/ui/onboarding/OnboardingFlow.kt
@@ -9,26 +9,14 @@ import dev.shizzi.CompatibilityState
 import dev.shizzi.ShizukuState
 import dev.shizzi.isCompatible
 
-/**
- * The steps, in order. Adding one is an entry here plus the composable it
- * names; the wizard reads the count from this and needs no other change.
- */
 enum class OnboardingStep { WELCOME, SHIZUKU, COMPATIBILITY }
 
-/** What the flow needs from the app, grouped so it stays within the parameter limit. */
 data class OnboardingActions(
     val onRequestPermission: () -> Unit,
     val onCheckCompatibility: () -> Unit,
     val onFinish: () -> Unit,
 )
 
-/**
- * Runs the three steps and hands off to the app when the last one passes.
- *
- * No back navigation: each step is a precondition for the one after it, so
- * returning to an earlier one offers a user nothing to change. The system back
- * gesture leaves the app, as it does on Home.
- */
 @Composable
 fun OnboardingFlow(
     shizukuState: ShizukuState,
@@ -37,8 +25,6 @@ fun OnboardingFlow(
 ) {
     val current = rememberOnboardingStep()
 
-    // Started with the step rather than by a button, so a device that passes
-    // shows its verdict on arrival. Check then re-runs it for one that did not.
     LaunchedEffect(current.value) {
         if (current.value == OnboardingStep.COMPATIBILITY) actions.onCheckCompatibility()
     }
@@ -65,7 +51,6 @@ fun OnboardingFlow(
     )
 }
 
-/** Saveable so a rotation mid-onboarding does not return to Welcome. */
 @Composable
 private fun rememberOnboardingStep(): MutableState<OnboardingStep> =
     rememberSaveable { mutableStateOf(OnboardingStep.WELCOME) }
@@ -76,12 +61,6 @@ private fun welcomeStep(onNext: () -> Unit) = WizardStep(
     primary = WizardAction(label = "Get started", onClick = onNext),
 )
 
-/**
- * Continue is gated on Shizuku being ready, not merely installed: the next step
- * asks the privileged process a question, and arriving there unable to bind
- * would report the device incompatible over a Shizuku that is simply not
- * running.
- */
 private fun shizukuStep(
     state: ShizukuState,
     onGrant: () -> Unit,
@@ -96,11 +75,6 @@ private fun shizukuStep(
     ),
 )
 
-/**
- * Finish appears only for a device that passed. One that did not keeps Check,
- * which is the only action left worth offering — Shizuku may have been granted
- * since, and nothing else on this screen can change the answer.
- */
 private fun compatibilityStep(
     state: CompatibilityState,
     actions: OnboardingActions,

--- a/app/src/main/java/dev/shizzi/ui/onboarding/ShizukuStatusIcon.kt
+++ b/app/src/main/java/dev/shizzi/ui/onboarding/ShizukuStatusIcon.kt
@@ -14,17 +14,8 @@ import androidx.compose.ui.unit.dp
 import dev.shizzi.ShizukuState
 import dev.shizzi.ui.theme.ShizziTheme
 
-/** A verdict at the scale of the welcome mark, not a row's trailing glyph. */
 private val StatusIconSize = 120.dp
 
-/**
- * Whether Shizuku is usable, under the card that says why.
- *
- * Three marks for four states: the card distinguishes not-installed from
- * not-running from permission-required, and all three mean the same thing here
- * — the next step cannot run. Repeating that distinction in a glyph would
- * restate what the rows above already say.
- */
 @Composable
 fun ShizukuStatusIcon(state: ShizukuState) {
     val colors = ShizziTheme.colors

--- a/app/src/main/java/dev/shizzi/ui/onboarding/ShizukuStep.kt
+++ b/app/src/main/java/dev/shizzi/ui/onboarding/ShizukuStep.kt
@@ -10,20 +10,11 @@ import androidx.compose.ui.Modifier
 import dev.shizzi.ShizukuState
 import dev.shizzi.ui.ShizukuCard
 
-/**
- * The settings screen's Shizuku card, unchanged.
- *
- * Shared rather than copied: this is the same question asked at a different
- * time, and a second rendering of it would be a second thing to keep correct as
- * the states change.
- */
 @Composable
 fun ShizukuStep(state: ShizukuState, onGrant: () -> Unit) {
     Column(modifier = Modifier.fillMaxSize()) {
         ShizukuCard(state = state, onGrant = onGrant)
 
-        // Takes the space between the card and the footer and centres in it,
-        // rather than hanging at a fixed gap under the card.
         Box(
             modifier = Modifier.fillMaxWidth().weight(1f),
             contentAlignment = Alignment.Center,

--- a/app/src/main/java/dev/shizzi/ui/onboarding/StepTitle.kt
+++ b/app/src/main/java/dev/shizzi/ui/onboarding/StepTitle.kt
@@ -12,58 +12,32 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import dev.shizzi.ui.theme.ShizziTheme
 
-/** Well past [ShizziTypography.display]'s 28sp, which the app's screens use. */
 private val TitleSize = 72.sp
 
-/**
- * The floor for a title that has to shrink. Still well above the app's own
- * 28sp headings, so a wrapped step does not stop reading as a wizard title.
- */
 private val MinTitleSize = 40.sp
 
-/** Fine enough that the drop to a fitting size is not visible as a jump. */
 private val TitleStep = 1.sp
 
-/**
- * The onboarding heading treatment, shared by every step.
- *
- * Built on `display` rather than replacing it: the app's own screens set titles
- * at 28sp, and a wizard step is a different kind of page — no back button, no
- * rule, the title alone at the top of an open screen.
- */
 val StepTitleStyle: TextStyle
     @Composable get() = ShizziTheme.typography.display.copy(
         fontSize = TitleSize,
-        // Breaks between words only. The default strategy is free to break
-        // inside one when it does not fit, which at 72sp is most of them.
+
         lineBreak = LineBreak.Heading,
-        // The display style's tracking is set for 28sp; at this size the same
-        // proportion opens the word up rather than closing it.
+
         letterSpacing = (-0.04).em,
-        // Trims the font's built-in leading, which at 72sp leaves a visible gap
-        // above the cap height and unbalances whatever sits with it.
+
         lineHeightStyle = LineHeightStyle(
             alignment = LineHeightStyle.Alignment.Center,
             trim = LineHeightStyle.Trim.Both,
         ),
     )
 
-/**
- * Names a step above its content.
- *
- * [TitleSize] is a ceiling rather than a fixed size: "Compatibility" is wider
- * than the screen at 72sp, and with no legal break inside a word the layout
- * splits it mid-word. Shrinking only the titles that do not fit keeps every
- * other step at full size.
- */
 @Composable
 fun StepTitle(text: String) {
     BasicText(
         text = text,
         style = StepTitleStyle.copy(color = ShizziTheme.colors.onSurface),
-        // One line is what forces the shrink: given unbounded height, autoSize
-        // fits by wrapping — and with no legal break inside "Compatibility",
-        // wrapping means splitting it mid-word.
+
         maxLines = 1,
         autoSize = TextAutoSize.StepBased(
             minFontSize = MinTitleSize,

--- a/app/src/main/java/dev/shizzi/ui/onboarding/WelcomeStep.kt
+++ b/app/src/main/java/dev/shizzi/ui/onboarding/WelcomeStep.kt
@@ -16,18 +16,8 @@ import androidx.compose.ui.unit.dp
 import dev.shizzi.ui.shimmer
 import dev.shizzi.ui.theme.ShizziTheme
 
-/** Most of the screen's width, so the mark carries the page on its own. */
 private val WelcomeIconSize = 280.dp
 
-/**
- * The mark, then the word.
- *
- * The icon centres itself in the space above the title, which stays on the
- * left margin every following step's title uses.
- *
- * No paragraph under it: the two steps that follow are the explanation, and a
- * summary here would be read once and then repeated.
- */
 @Composable
 fun WelcomeStep() {
     Column(
@@ -41,9 +31,7 @@ fun WelcomeStep() {
             tint = ShizziTheme.colors.primary,
             modifier = Modifier
                 .size(WelcomeIconSize)
-                // Always sweeping: the home glyph shimmers to say a session is
-                // coming up, where here there is nothing to wait for and the
-                // mark is simply alive while the user reads the screen.
+
                 .shimmer(isActive = true, highlight = ShizziTheme.colors.primaryBright)
                 .padding(bottom = ShizziTheme.spacing.xl),
         )

--- a/app/src/main/java/dev/shizzi/ui/onboarding/Wizard.kt
+++ b/app/src/main/java/dev/shizzi/ui/onboarding/Wizard.kt
@@ -18,23 +18,8 @@ import dev.shizzi.ui.theme.ScreenPadding
 import dev.shizzi.ui.theme.ShizziTheme
 import dev.shizzi.ui.theme.brutalSurface
 
-/** One dot per step. Sized to read as a marker rather than a tappable control. */
 private val ProgressDotSize = 10.dp
 
-/**
- * One screen of the wizard.
- *
- * A step says what it shows and what its buttons do; it does not place them.
- * The frame is [Wizard]'s, so a step added later cannot drift from the others
- * by laying out its own title or footer.
- *
- * [title] is empty for a step whose content is its own heading — Welcome sets
- * the word at display size as the thing being introduced, and a title above it
- * would be that word twice.
- *
- * [content] is given the width and left to fill it — the frame contributes the
- * screen padding, the title, and the space the footer occupies, nothing else.
- */
 data class WizardStep(
     val title: String,
     val content: @Composable () -> Unit,
@@ -42,26 +27,12 @@ data class WizardStep(
     val secondary: WizardAction? = null,
 )
 
-/**
- * A footer button.
- *
- * [isEnabled] rather than omitting a button that cannot yet be pressed: a
- * footer that gains a control when a check finishes moves the one the user was
- * reaching for.
- */
 data class WizardAction(
     val label: String,
     val isEnabled: Boolean = true,
     val onClick: () -> Unit,
 )
 
-/**
- * Content, progress, footer — the same three bands on every step.
- *
- * Title and content are centred together in the band between the header and the
- * progress dots, so a short step does not sit against the footer with the top
- * half of the screen empty.
- */
 @Composable
 fun Wizard(step: WizardStep, currentIndex: Int, stepCount: Int) {
     Column(
@@ -90,13 +61,6 @@ fun Wizard(step: WizardStep, currentIndex: Int, stepCount: Int) {
     }
 }
 
-/**
- * Filled for where the user is, outlined for everywhere else — the same
- * "this one is active" vocabulary [ThemePicker] uses, so the app has one.
- *
- * Steps behind the user are not marked as done: this wizard cannot be
- * navigated backward, so a third state would distinguish nothing actionable.
- */
 @Composable
 private fun ProgressDots(currentIndex: Int, stepCount: Int, modifier: Modifier = Modifier) {
     Row(
@@ -112,10 +76,6 @@ private fun ProgressDots(currentIndex: Int, stepCount: Int, modifier: Modifier =
     }
 }
 
-/**
- * Square, like every other surface here. A circle would be the one round
- * element in an app whose corners are 0dp without exception.
- */
 @Composable
 private fun ProgressDot(isCurrent: Boolean) {
     val colors = ShizziTheme.colors
@@ -127,11 +87,6 @@ private fun ProgressDot(isCurrent: Boolean) {
     )
 }
 
-/**
- * The primary sits above the secondary rather than beside it: the buttons are
- * full-width, and a row of two would halve the primary to give equal weight to
- * the lesser choice.
- */
 @Composable
 private fun WizardFooter(primary: WizardAction, secondary: WizardAction?) {
     Column(verticalArrangement = Arrangement.spacedBy(ShizziTheme.spacing.md)) {

--- a/app/src/main/java/dev/shizzi/ui/onboarding/WizardButton.kt
+++ b/app/src/main/java/dev/shizzi/ui/onboarding/WizardButton.kt
@@ -15,17 +15,8 @@ import dev.shizzi.ui.theme.ShizziTheme
 import dev.shizzi.ui.theme.brutalSurface
 import dev.shizzi.ui.theme.isPressed
 
-/** Matches the connect button, so the two read as the same control. */
 private val ButtonHeight = 56.dp
 
-/**
- * Full-width footer button.
- *
- * Turquoise for the step's own action and neutral for the way past it, which
- * keeps the app's rule that the saturated element is the one worth acting on.
- * A disabled button keeps its footprint and loses its fill, so a footer whose
- * primary becomes available does not reflow.
- */
 @Composable
 fun WizardButton(action: WizardAction, isPrimary: Boolean) {
     val interaction = remember { MutableInteractionSource() }

--- a/app/src/main/java/dev/shizzi/ui/theme/Color.kt
+++ b/app/src/main/java/dev/shizzi/ui/theme/Color.kt
@@ -3,17 +3,11 @@ package dev.shizzi.ui.theme
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 
-/**
- * Named by role rather than hue. Turquoise is the only colour in the app and
- * marks a state worth acting on, not one merely true — so an error speaks
- * through the text of its toast rather than a red icon carrying alarm without
- * information.
- */
 @Immutable
 data class ShizziColors(
     val primary: Color,
     val onPrimary: Color,
-    /** A lighter [primary], for a highlight that crosses a turquoise mark. */
+
     val primaryBright: Color,
     val background: Color,
     val surface: Color,
@@ -24,7 +18,6 @@ data class ShizziColors(
     val isDark: Boolean,
 )
 
-/** Turquoise is light enough that white on it fails contrast at body sizes. */
 private val OnPrimary = Color(0xFF000000)
 
 val LightColors = ShizziColors(
@@ -40,16 +33,10 @@ val LightColors = ShizziColors(
     isDark = false,
 )
 
-/**
- * Inverts the structural colours rather than recolouring them: the flat offset
- * shadow is load-bearing, and a black shadow on a near-black background is
- * invisible. Borders and shadows go white — a different look, not a tinted copy.
- */
 val DarkColors = ShizziColors(
     primary = Color(0xFF2DD4BF),
     onPrimary = OnPrimary,
-    // A step further up the ramp than light's, so the sweep still reads as
-    // brighter than the already-lighter dark-theme primary it crosses.
+
     primaryBright = Color(0xFF99F6E4),
     background = Color(0xFF0C0A09),
     surface = Color(0xFF1C1917),

--- a/app/src/main/java/dev/shizzi/ui/theme/Shape.kt
+++ b/app/src/main/java/dev/shizzi/ui/theme/Shape.kt
@@ -13,28 +13,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.dp
 
-/** Every corner in the app. Sharp, without exception. */
 val CornerRadius = 0.dp
 
-/** Border thickness, thick enough to read as structure rather than as a hairline. */
 val BorderWidth = 2.dp
 
-/** Shadow displacement, down and to the right. Zero blur. */
 val ShadowOffset = 4.dp
 
-/**
- * The app's one surface treatment: hard offset shadow, thick border, flat fill.
- * Material's elevation shadow is blurred and colour-filtered, so the shadow is
- * a plain displaced rectangle instead. One modifier for every bordered element,
- * so the treatment cannot drift per component.
- *
- * The border always takes the theme's structural colour, since its job is to
- * separate surface from page — tinting it to match a turquoise fill drew it in
- * the colour it sits on and it vanished.
- *
- * @param isPressed shifts the element into its shadow, which is suppressed, so
- *   the surface appears to depress to meet the page.
- */
 fun Modifier.brutalSurface(
     fill: Color,
     isPressed: Boolean = false,
@@ -49,8 +33,6 @@ fun Modifier.brutalSurface(
             val stroke = BorderWidth.toPx()
             val shadow = ShadowOffset.toPx()
 
-            // The element has moved into the space the shadow occupied, so
-            // drawing both would double the mass.
             if (!isPressed) {
                 drawRect(
                     color = colors.shadow,
@@ -61,8 +43,6 @@ fun Modifier.brutalSurface(
 
             drawRect(color = fill, size = size)
 
-            // Inset by half the stroke so the border sits inside the bounds
-            // rather than straddling them, which would clip against a sibling.
             drawRect(
                 color = border,
                 topLeft = Offset(stroke / 2f, stroke / 2f),
@@ -72,9 +52,5 @@ fun Modifier.brutalSurface(
         }
 }
 
-/**
- * Kept beside [brutalSurface] so a caller wiring up a pressable surface does
- * not have to remember which interaction to collect.
- */
 @Composable
 fun InteractionSource.isPressed(): Boolean = collectIsPressedAsState().value

--- a/app/src/main/java/dev/shizzi/ui/theme/Spacing.kt
+++ b/app/src/main/java/dev/shizzi/ui/theme/Spacing.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-/** A 4dp grid. Anything off this scale is a mistake, not a decision. */
 @Immutable
 data class ShizziSpacing(
     val xs: Dp = 4.dp,
@@ -18,11 +17,8 @@ data class ShizziSpacing(
 
 val Spacing = ShizziSpacing()
 
-/** Screen edge padding. */
 val ScreenPadding = Spacing.lg
 
-/** Header height, shared by all three screens so they line up. */
 val HeaderHeight = 56.dp
 
-/** The floor for anything tappable: a 24dp icon still needs 48dp around it. */
 val MinTouchTarget = 48.dp

--- a/app/src/main/java/dev/shizzi/ui/theme/Theme.kt
+++ b/app/src/main/java/dev/shizzi/ui/theme/Theme.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 
-/** The three values the theme setting can take. */
 enum class ThemeChoice { SYSTEM, LIGHT, DARK }
 
 private val LocalShizziColors: ProvidableCompositionLocal<ShizziColors> =
@@ -23,10 +22,6 @@ private val LocalShizziTypography: ProvidableCompositionLocal<ShizziTypography> 
 private val LocalShizziSpacing: ProvidableCompositionLocal<ShizziSpacing> =
     staticCompositionLocalOf { Spacing }
 
-/**
- * `ShizziTheme.colors.primary` rather than a global import, so a preview or a
- * test can substitute a different set.
- */
 object ShizziTheme {
     val colors: ShizziColors
         @Composable @ReadOnlyComposable get() = LocalShizziColors.current
@@ -38,14 +33,6 @@ object ShizziTheme {
         @Composable @ReadOnlyComposable get() = LocalShizziSpacing.current
 }
 
-/**
- * SYSTEM is the only value that consults the platform; LIGHT and DARK are
- * absolute, which is the point of offering them.
- *
- * MaterialTheme is supplied underneath with the same palette, because Material
- * components read from it and its defaults would put stock purple inside an
- * otherwise turquoise app.
- */
 @Composable
 fun ShizziTheme(
     choice: ThemeChoice = ThemeChoice.SYSTEM,
@@ -71,7 +58,6 @@ fun ShizziTheme(
     }
 }
 
-/** Only the roles Material components actually read; nothing renders the rest. */
 private fun materialSchemeFrom(colors: ShizziColors, isDark: Boolean) = when {
     isDark -> darkColorScheme(
         primary = colors.primary,

--- a/app/src/main/java/dev/shizzi/ui/theme/Type.kt
+++ b/app/src/main/java/dev/shizzi/ui/theme/Type.kt
@@ -11,18 +11,6 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import dev.shizzi.R
 
-/**
- * Declares one weight of a variable font. All three faces ship as single
- * variable files — three static JetBrains Mono weights measured 808 KB against
- * 296 KB.
- *
- * The variation axis never reaches the typeface: Compose's resource [Font]
- * loads through `ResourcesCompat.getFont(context, resId)`, which takes an ID
- * and caches on it, so every entry pointing at one file resolves to that file's
- * *default* weight whatever was requested. Hence [Display] being rebased. The
- * settings below record intent and cost nothing; the declared [FontWeight] does
- * still matter, as how a family matches a request to an entry.
- */
 @OptIn(ExperimentalTextApi::class)
 private fun variableWeight(resource: Int, weight: Int) = Font(
     resource,
@@ -36,11 +24,6 @@ private val Mono = FontFamily(
     variableWeight(R.font.jetbrains_mono, 700),
 )
 
-/**
- * Rebased to default to Medium: upstream the axis is 300-700 defaulting to 300,
- * which rendered every heading Light. The bundled file is a partial instance
- * limited to `wght=500:500:700`.
- */
 private val Display = FontFamily(
     variableWeight(R.font.space_grotesk, 500),
     variableWeight(R.font.space_grotesk, 700),
@@ -52,15 +35,6 @@ private val Sans = FontFamily(
     variableWeight(R.font.inter, 500),
 )
 
-/**
- * Split three ways by role: Space Grotesk for headings, where letterforms are
- * visible and a neutral face says nothing; Inter for strings long enough that
- * reading them is the point; JetBrains Mono for labels, badges, and log lines,
- * which name a thing rather than being read as a sentence.
- *
- * The split is what keeps mono off prose, where uniform advance widths flatten
- * the word shapes readers recognise.
- */
 @Immutable
 data class ShizziTypography(
     val display: TextStyle,
@@ -74,8 +48,7 @@ data class ShizziTypography(
 )
 
 val Typography = ShizziTypography(
-    // Slight negative tracking: Space Grotesk sets a touch loose at display
-    // sizes, and the default spacing reads as a gap rather than a word.
+
     display = TextStyle(
         fontFamily = Display,
         fontSize = 28.sp,
@@ -83,7 +56,6 @@ val Typography = ShizziTypography(
         letterSpacing = (-0.02).em,
     ),
 
-    /** Screen titles. */
     heading = TextStyle(
         fontFamily = Display,
         fontSize = 20.sp,
@@ -91,24 +63,16 @@ val Typography = ShizziTypography(
         letterSpacing = (-0.01).em,
     ),
 
-    /**
-     * Names a row: a settings item, a section. Above [body] so a name outranks
-     * its own description — borrowing `label` put a 13sp name over a 14sp
-     * subtitle and inverted the hierarchy.
-     */
     subheading = TextStyle(
         fontFamily = Display,
         fontSize = 17.sp,
         fontWeight = FontWeight.W500,
     ),
 
-    /** Button text, which is uppercase wherever it is used. */
     title = TextStyle(fontFamily = Mono, fontSize = 18.sp, fontWeight = FontWeight.W700),
 
     label = TextStyle(fontFamily = Mono, fontSize = 13.sp, fontWeight = FontWeight.W500),
 
-    // Uppercase everywhere it is used; the tracking is what makes 11sp read as
-    // deliberate rather than merely small.
     caption = TextStyle(
         fontFamily = Mono,
         fontSize = 11.sp,

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,27 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  The wifi_tethering mark, the same symbol the home screen shows as its status
-  glyph, so the launcher icon and the app's one large element are the same
-  shape rather than two drawings of the same idea.
-
-  Sized for the adaptive-icon mask: the 108dp canvas shows only its middle
-  72dp, and launchers crop that further to a circle, squircle or rounded
-  square of their choosing. The scale is set from the mark's half-diagonal
-  rather than its width, since the corners are what a circular mask reaches
-  first — 46.9x40.5dp puts every corner exactly 31dp from centre, inside the
-  33dp safe radius with room to spare.
-
-  The vertical offset is set by eye against the rendered icon, not by
-  centring the path's bounding box. The mark's lowest fifth is only the two
-  thin arc tips descending past the dot, so a box-centred mark measures
-  balanced while reading as sitting low — the visible weight is all in the
-  arcs above. 25.2 is where the black above the outer arc and the black below
-  the tips look equal at launcher size.
-
-  Path data is the official Material Symbols export at weight 400, whose
-  viewBox is 960 units with the Y axis pointing up; the translate flips it
-  into Android's Y-down space.
--->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  Android 8+ draws the launcher icon from these layers and applies its own
-  mask, so the shape follows whatever the launcher uses rather than being
-  baked in.
-
-  The monochrome layer is what Android 13+ themed icons tint to the user's
-  wallpaper palette; without it the icon opts out of theming and looks
-  out of place on a themed home screen. It reuses the foreground, whose mark
-  is a single path — the tint replaces its colour outright, so the turquoise
-  is irrelevant there.
--->
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,16 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  Same layers as ic_launcher; some launchers request the round variant by
-  name. Android 8+ draws the launcher icon from these layers and applies its own
-  mask, so the shape follows whatever the launcher uses rather than being
-  baked in.
-
-  The monochrome layer is what Android 13+ themed icons tint to the user's
-  wallpaper palette; without it the icon opts out of theming and looks
-  out of place on a themed home screen. It reuses the foreground, whose mark
-  is a single path — the tint replaces its colour outright, so the turquoise
-  is irrelevant there.
--->
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />

--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,16 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  The launcher icon's backdrop.
-
-  Near-black rather than the app's turquoise: the mark is the accent colour,
-  and an accent-on-accent icon would have no contrast. This is the same value
-  as the dark theme's background, so the icon reads as a piece of the app
-  rather than a separate object, and the turquoise on it is the one saturated
-  element — the rule the rest of the app follows.
-
-  Held apart from the adaptive icon's own XML because the legacy round icon
-  and the monochrome layer reference it too.
--->
 <resources>
     <color name="ic_launcher_background">#0C0A09</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!--
-      Compose supplies the real theming via MaterialTheme; this exists only so
-      the activity has a platform theme before the composition starts. Kept on
-      the DeviceDefault DayNight parent to avoid pulling in the Material
-      Components view library for a single attribute.
-    -->
     <style name="Theme.Shizzi" parent="@android:style/Theme.DeviceDefault.DayNight">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowActionBar">false</item>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  The one directory the export shares from.
-
-  Scoped to a subdirectory rather than to files/ itself: the app's own storage
-  also holds session.log, and a provider rooted higher would grant any app
-  holding the share intent a path to read it.
--->
 <paths>
     <files-path name="exports" path="exports/" />
 </paths>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,5 @@
 plugins {
-    // 8.9 rather than 8.7: lint loads the lint AARs bundled with the libraries
-    // it checks, and the Compose 2025.08.00 BOM brings Compose 1.9 and (through
-    // material3) lifecycle 2.9, whose detectors are compiled against a newer
-    // Kotlin analysis API than 8.7.3's lint can load. It died with
-    // IncompatibleClassChangeError before checking a single file. Pinning the
-    // libraries back was the wrong lever -- it only moved the crash from one
-    // detector to the next.
+
     id("com.android.application") version "8.9.2" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false


### PR DESCRIPTION
Strips every comment from the codebase: KDoc and `//` in Kotlin/Gradle, `<!-- -->` in XML, `#` in ProGuard rules.