### PR TITLE
feat: intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,22 @@ and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   card and its former section.
 - **Shizuku** can be acted on from any state: not installed opens its releases
   page, not running launches it, and ungranted requests permission.
+- **Automation.** Other apps can start, stop, toggle, and query a session
+  through intents, for automation from Tasker, MacroDroid, and the like. Off by
+  default, and every command carries a token. The token card copies and
+  regenerates it, and a setup dialog lists the values an automation app needs
+  for each action. See [automation](docs/automation.md).
 
 ### Fixed
 
 - The notification permission dialog no longer appears over the welcome screen
   on first launch. It is asked for in the Permissions step, where it is
   explained, and a denial is now visible and recoverable instead of silent.
+- **Background starts.** Android 12 and up blocked intent-triggered sessions
+  from starting the foreground service, so a command was accepted and then did
+  nothing. Battery optimization exemption lifts the restriction and is now
+  surfaced as a permission, and a start that cannot be delivered reports the
+  reason instead of failing silently.
 
 ## [0.3.0] - 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Download the APK from the
 - 🛡️ **VPN compatible.** Stay private on every connected device.
 - ⚙️ **Uses your existing hotspot.** No extra configuration required.
 - 🙌 **No root.** Shizuku is all it needs.
+- 🤖 **Automatable.** Start and stop from Tasker or MacroDroid. See
+  [automation](docs/automation.md).
 
 ## Build
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,17 @@
                     down the hotspot if the privileged helper process dies" />
         </service>
 
+        <receiver
+            android:name=".AutomationReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="dev.shizzi.action.START" />
+                <action android:name="dev.shizzi.action.STOP" />
+                <action android:name="dev.shizzi.action.TOGGLE" />
+                <action android:name="dev.shizzi.action.QUERY_STATUS" />
+            </intent-filter>
+        </receiver>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.exports"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
     <uses-permission
         android:name="android.permission.MANAGE_TEST_NETWORKS"
         tools:ignore="ProtectedPermissions" />

--- a/app/src/main/java/dev/shizzi/App.kt
+++ b/app/src/main/java/dev/shizzi/App.kt
@@ -17,15 +17,17 @@ class App : Application() {
         instance = this
 
         SessionLog.useAppStorage(filesDir)
-        applyLoggingSetting()
+        applyStoredSettings()
 
         liftHiddenApiRestrictions()
     }
 
-    private fun applyLoggingSetting() {
+    private fun applyStoredSettings() {
         CoroutineScope(Dispatchers.IO).launch {
             val isLogging = settingsStore.settings.first().isLogging
             SessionLog.setEnabled(isLogging)
+
+            settingsStore.backfillTokenIfEnabled()
         }
     }
 

--- a/app/src/main/java/dev/shizzi/AppPermission.kt
+++ b/app/src/main/java/dev/shizzi/AppPermission.kt
@@ -5,6 +5,7 @@ import android.os.Build
 
 enum class AppPermission {
     NOTIFICATIONS,
+    BATTERY_EXEMPTION,
 }
 
 data class PermissionStatus(
@@ -15,19 +16,23 @@ data class PermissionStatus(
 val AppPermission.title: String
     get() = when (this) {
         AppPermission.NOTIFICATIONS -> "Notifications"
+        AppPermission.BATTERY_EXEMPTION -> "Background activity"
     }
 
 val AppPermission.rationale: String
     get() = when (this) {
         AppPermission.NOTIFICATIONS -> "Required to keep your session running"
+        AppPermission.BATTERY_EXEMPTION -> "Required for external session management"
     }
 
-val AppPermission.manifestName: String
+val AppPermission.manifestName: String?
     get() = when (this) {
         AppPermission.NOTIFICATIONS -> Manifest.permission.POST_NOTIFICATIONS
+        AppPermission.BATTERY_EXEMPTION -> null
     }
 
 val AppPermission.isApplicable: Boolean
     get() = when (this) {
         AppPermission.NOTIFICATIONS -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+        AppPermission.BATTERY_EXEMPTION -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     }

--- a/app/src/main/java/dev/shizzi/Automation.kt
+++ b/app/src/main/java/dev/shizzi/Automation.kt
@@ -1,0 +1,78 @@
+package dev.shizzi
+
+enum class AutomationCommand { START, STOP, TOGGLE, QUERY_STATUS }
+
+sealed interface AutomationRefusal {
+    data object Disabled : AutomationRefusal
+    data object BadToken : AutomationRefusal
+    data object UnknownAction : AutomationRefusal
+}
+
+object Automation {
+
+    const val ACTION_START = "dev.shizzi.action.START"
+    const val ACTION_STOP = "dev.shizzi.action.STOP"
+    const val ACTION_TOGGLE = "dev.shizzi.action.TOGGLE"
+    const val ACTION_QUERY_STATUS = "dev.shizzi.action.QUERY_STATUS"
+
+    const val ACTION_RESULT = "dev.shizzi.action.SESSION_RESULT"
+
+    const val EXTRA_TOKEN = "token"
+
+    const val EXTRA_COMMAND = "command"
+    const val EXTRA_ACCEPTED = "accepted"
+    const val EXTRA_REFUSAL = "refusal"
+    const val EXTRA_STATUS = "status"
+    const val EXTRA_IS_ACTIVE = "isActive"
+    const val EXTRA_DETAIL = "detail"
+    const val EXTRA_INTERFACE = "interface"
+    const val EXTRA_ERROR = "error"
+    const val EXTRA_CLIENT_COUNT = "clientCount"
+    const val EXTRA_BYTES_UP = "bytesUp"
+    const val EXTRA_BYTES_DOWN = "bytesDown"
+
+    fun actionFor(command: AutomationCommand): String = when (command) {
+        AutomationCommand.START -> ACTION_START
+        AutomationCommand.STOP -> ACTION_STOP
+        AutomationCommand.TOGGLE -> ACTION_TOGGLE
+        AutomationCommand.QUERY_STATUS -> ACTION_QUERY_STATUS
+    }
+
+    fun commandFor(action: String?): AutomationCommand? = when (action) {
+        ACTION_START -> AutomationCommand.START
+        ACTION_STOP -> AutomationCommand.STOP
+        ACTION_TOGGLE -> AutomationCommand.TOGGLE
+        ACTION_QUERY_STATUS -> AutomationCommand.QUERY_STATUS
+        else -> null
+    }
+
+    fun refuse(settings: Settings, presented: String?): AutomationRefusal? = when {
+        !settings.isAutomationEnabled -> AutomationRefusal.Disabled
+        !isTokenAccepted(settings.automationToken, presented) -> AutomationRefusal.BadToken
+        else -> null
+    }
+
+    private fun isTokenAccepted(expected: String, presented: String?): Boolean {
+        if (expected.isEmpty()) return false
+        return presented != null && isEqualInConstantTime(expected, presented)
+    }
+
+    private fun isEqualInConstantTime(expected: String, presented: String): Boolean {
+        val expectedBytes = expected.toByteArray()
+        val presentedBytes = presented.toByteArray()
+        if (expectedBytes.size != presentedBytes.size) return false
+
+        var difference = 0
+        expectedBytes.indices.forEach { index ->
+            difference = difference or (expectedBytes[index].toInt() xor presentedBytes[index].toInt())
+        }
+        return difference == 0
+    }
+
+    fun describe(refusal: AutomationRefusal): String = when (refusal) {
+        AutomationRefusal.Disabled ->
+            "automation is off; enable it in Settings › Advanced"
+        AutomationRefusal.BadToken -> "token does not match the one set in Settings"
+        AutomationRefusal.UnknownAction -> "unrecognized action"
+    }
+}

--- a/app/src/main/java/dev/shizzi/AutomationReceiver.kt
+++ b/app/src/main/java/dev/shizzi/AutomationReceiver.kt
@@ -1,0 +1,84 @@
+package dev.shizzi
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+class AutomationReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val command = Automation.commandFor(intent.action)
+        if (command == null) {
+            AutomationResult.refuse(context, null, AutomationRefusal.UnknownAction)
+            return
+        }
+
+        val token = intent.getStringExtra(Automation.EXTRA_TOKEN)
+        val pending = goAsync()
+        val application = context.applicationContext
+
+        CoroutineScope(Dispatchers.Default).launch {
+            try {
+                dispatch(application, command, token)
+            } finally {
+                pending.finish()
+            }
+        }
+    }
+
+    private suspend fun dispatch(context: Context, command: AutomationCommand, token: String?) {
+        val settings = (context as App).settingsStore.settings.first()
+
+        val refusal = Automation.refuse(settings, token)
+        if (refusal != null) {
+            SessionLog.warn("automation ${command.name} refused: ${Automation.describe(refusal)}")
+            AutomationResult.refuse(context, command, refusal)
+            return
+        }
+
+        SessionLog.info("automation ${command.name} accepted")
+        apply(context, command)
+    }
+
+    private fun apply(context: Context, command: AutomationCommand) {
+        val resolved = resolve(command)
+        if (resolved == AutomationCommand.QUERY_STATUS) {
+            AutomationResult.announce(context, command, SessionService.liveState.value)
+            return
+        }
+
+        runCatching { deliver(context, resolved, command) }
+            .onFailure { failure -> reportUndelivered(context, command, failure) }
+    }
+
+    private fun deliver(context: Context, resolved: AutomationCommand, reportAs: AutomationCommand) {
+        when (resolved) {
+            AutomationCommand.STOP -> SessionService.stop(context, reportAs)
+            else -> SessionService.start(context, reportAs)
+        }
+    }
+
+    private fun reportUndelivered(
+        context: Context,
+        command: AutomationCommand,
+        failure: Throwable,
+    ) {
+        val reason = "${failure.javaClass.simpleName}: ${failure.message}"
+        SessionLog.error("automation ${command.name} could not reach the session service: $reason")
+        AutomationResult.fail(context, command, reason)
+    }
+
+    private fun resolve(command: AutomationCommand): AutomationCommand = when (command) {
+        AutomationCommand.TOGGLE -> toggleTarget()
+        else -> command
+    }
+
+    private fun toggleTarget(): AutomationCommand = when {
+        SessionService.isRunning -> AutomationCommand.STOP
+        else -> AutomationCommand.START
+    }
+}

--- a/app/src/main/java/dev/shizzi/AutomationResult.kt
+++ b/app/src/main/java/dev/shizzi/AutomationResult.kt
@@ -1,0 +1,44 @@
+package dev.shizzi
+
+import android.content.Context
+import android.content.Intent
+
+object AutomationResult {
+
+    fun announce(context: Context, command: AutomationCommand, state: SessionUiState) {
+        val intent = accepted(command).apply {
+            putExtra(Automation.EXTRA_STATUS, state.status.name)
+            putExtra(Automation.EXTRA_IS_ACTIVE, state.status == UiStatus.CONNECTED)
+            putExtra(Automation.EXTRA_DETAIL, state.detail)
+            putExtra(Automation.EXTRA_INTERFACE, state.interfaceName)
+            putExtra(Automation.EXTRA_ERROR, state.lastError)
+            putExtra(Automation.EXTRA_CLIENT_COUNT, state.clientCount)
+            putExtra(Automation.EXTRA_BYTES_UP, state.traffic.up)
+            putExtra(Automation.EXTRA_BYTES_DOWN, state.traffic.down)
+        }
+        context.sendBroadcast(intent)
+    }
+
+    fun refuse(context: Context, command: AutomationCommand?, refusal: AutomationRefusal) {
+        val intent = Intent(Automation.ACTION_RESULT).apply {
+            command?.let { putExtra(Automation.EXTRA_COMMAND, it.name) }
+            putExtra(Automation.EXTRA_ACCEPTED, false)
+            putExtra(Automation.EXTRA_REFUSAL, Automation.describe(refusal))
+        }
+        context.sendBroadcast(intent)
+    }
+
+    fun fail(context: Context, command: AutomationCommand, reason: String) {
+        val intent = accepted(command).apply {
+            putExtra(Automation.EXTRA_STATUS, UiStatus.ERROR.name)
+            putExtra(Automation.EXTRA_IS_ACTIVE, false)
+            putExtra(Automation.EXTRA_ERROR, reason)
+        }
+        context.sendBroadcast(intent)
+    }
+
+    private fun accepted(command: AutomationCommand) = Intent(Automation.ACTION_RESULT).apply {
+        putExtra(Automation.EXTRA_COMMAND, command.name)
+        putExtra(Automation.EXTRA_ACCEPTED, true)
+    }
+}

--- a/app/src/main/java/dev/shizzi/AutomationToken.kt
+++ b/app/src/main/java/dev/shizzi/AutomationToken.kt
@@ -1,0 +1,16 @@
+package dev.shizzi
+
+import java.security.SecureRandom
+
+object AutomationToken {
+
+    private const val LENGTH = 24
+    private const val ALPHABET = "abcdefghijkmnopqrstuvwxyz23456789"
+
+    fun generate(): String {
+        val random = SecureRandom()
+        return (1..LENGTH)
+            .map { ALPHABET[random.nextInt(ALPHABET.length)] }
+            .joinToString("")
+    }
+}

--- a/app/src/main/java/dev/shizzi/HomeScreen.kt
+++ b/app/src/main/java/dev/shizzi/HomeScreen.kt
@@ -14,6 +14,8 @@ import dev.shizzi.ui.LogActions
 import dev.shizzi.ui.LogPage
 import dev.shizzi.ui.Screen
 import dev.shizzi.ui.SessionToasts
+import dev.shizzi.ui.AutomationActions
+import dev.shizzi.ui.AutomationState
 import dev.shizzi.ui.SettingsActions
 import dev.shizzi.ui.SettingsPage
 import dev.shizzi.ui.SettingsState
@@ -36,6 +38,8 @@ data class AppActions(
     val onDismissDiagnostics: () -> Unit,
     val onClearLog: (onCleared: (String?) -> Unit) -> Unit,
     val onRestartOnboarding: () -> Unit,
+    val onSetAutomation: (Boolean) -> Unit,
+    val onRegenerateAutomationToken: () -> Unit,
 )
 
 @Composable
@@ -74,6 +78,10 @@ fun HomeScreen(state: AppState, actions: AppActions) {
                     theme = settings.theme,
                     isLogging = settings.isLogging,
                     isRunningDiagnostics = diagnostics is DiagnosticsState.Running,
+                    automation = AutomationState(
+                        isEnabled = settings.isAutomationEnabled,
+                        token = settings.automationToken,
+                    ),
                 ),
                 actions = SettingsActions(
                     onSetTheme = actions.onSetTheme,
@@ -83,7 +91,12 @@ fun HomeScreen(state: AppState, actions: AppActions) {
                     onGrantPermission = actions.onGrantPermission,
                     onShizukuAction = actions.onShizukuAction,
                     onRestartOnboarding = actions.onRestartOnboarding,
+                    automation = AutomationActions(
+                        onSetEnabled = actions.onSetAutomation,
+                        onRegenerateToken = actions.onRegenerateAutomationToken,
+                    ),
                 ),
+                toasts = toasts,
                 onBack = goHome,
             )
 

--- a/app/src/main/java/dev/shizzi/MainActivity.kt
+++ b/app/src/main/java/dev/shizzi/MainActivity.kt
@@ -95,6 +95,9 @@ class MainActivity : ComponentActivity() {
                             onDismissDiagnostics = viewModel::dismissDiagnostics,
                             onClearLog = viewModel::clearLog,
                             onRestartOnboarding = viewModel::restartOnboarding,
+                            onSetAutomation = viewModel::setAutomation,
+                            onRegenerateAutomationToken =
+                                viewModel::regenerateAutomationToken,
                         ),
                     )
                 }

--- a/app/src/main/java/dev/shizzi/MainActivity.kt
+++ b/app/src/main/java/dev/shizzi/MainActivity.kt
@@ -150,15 +150,20 @@ class MainActivity : ComponentActivity() {
         return true
     }
 
+    // A permission with no manifest name is granted on a settings screen in
+    // another app, so there is no dialog to launch and no result to wait for.
     private fun grantPermission(permission: AppPermission) {
-        if (isDialogSuppressed(permission)) {
+        val name = permission.manifestName
+
+        if (name == null || isDialogSuppressed(permission)) {
+            stopChain()
             viewModel.openPermissionSettings(permission)
             return
         }
 
         requested = permission
         asked += permission
-        permissionLauncher.launch(permission.manifestName)
+        permissionLauncher.launch(name)
     }
 
     private fun onPermissionResult() {
@@ -183,9 +188,10 @@ class MainActivity : ComponentActivity() {
     // shouldShowRequestPermissionRationale is also false before the first ask, so
     // only a permission this process has already requested can be suppressed.
     private fun isDialogSuppressed(permission: AppPermission): Boolean {
+        val name = permission.manifestName ?: return false
         if (permission !in asked) return false
 
-        return !shouldShowRequestPermissionRationale(permission.manifestName)
+        return !shouldShowRequestPermissionRationale(name)
     }
 
     private fun registerShizukuListeners() {

--- a/app/src/main/java/dev/shizzi/PermissionInspector.kt
+++ b/app/src/main/java/dev/shizzi/PermissionInspector.kt
@@ -2,6 +2,7 @@ package dev.shizzi
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.PowerManager
 
 class PermissionInspector(private val context: Context) {
 
@@ -17,7 +18,19 @@ class PermissionInspector(private val context: Context) {
     fun isGranted(permission: AppPermission): Boolean {
         if (!permission.isApplicable) return true
 
-        return context.checkSelfPermission(permission.manifestName) ==
-            PackageManager.PERMISSION_GRANTED
+        return when (permission) {
+            AppPermission.BATTERY_EXEMPTION -> isIgnoringBatteryOptimizations()
+            else -> isManifestPermissionGranted(permission)
+        }
     }
+
+    private fun isManifestPermissionGranted(permission: AppPermission): Boolean {
+        val name = permission.manifestName ?: return true
+
+        return context.checkSelfPermission(name) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun isIgnoringBatteryOptimizations(): Boolean = context
+        .getSystemService(PowerManager::class.java)
+        .isIgnoringBatteryOptimizations(context.packageName)
 }

--- a/app/src/main/java/dev/shizzi/PermissionRequest.kt
+++ b/app/src/main/java/dev/shizzi/PermissionRequest.kt
@@ -3,12 +3,14 @@ package dev.shizzi
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.provider.Settings as AndroidSettings
 
 class PermissionRequest(private val context: Context) {
 
     fun settingsIntentFor(permission: AppPermission): Intent = when (permission) {
         AppPermission.NOTIFICATIONS -> appNotificationSettings()
+        AppPermission.BATTERY_EXEMPTION -> batteryExemptionIntent()
     }
 
     fun open(permission: AppPermission) {
@@ -20,6 +22,10 @@ class PermissionRequest(private val context: Context) {
             SessionLog.warn("no screen for ${permission.name}: ${absent.message}")
         }
     }
+
+    private fun batteryExemptionIntent() =
+        Intent(AndroidSettings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+            .setData(Uri.fromParts("package", context.packageName, null))
 
     private fun appNotificationSettings() =
         Intent(AndroidSettings.ACTION_APP_NOTIFICATION_SETTINGS)

--- a/app/src/main/java/dev/shizzi/RenamedKeys.kt
+++ b/app/src/main/java/dev/shizzi/RenamedKeys.kt
@@ -1,0 +1,53 @@
+package dev.shizzi
+
+import androidx.datastore.core.DataMigration
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+
+object RenamedKeys {
+
+    private val RETIRED_AUTOMATION = booleanPreferencesKey("external_control")
+    private val RETIRED_TOKEN = stringPreferencesKey("external_control_token")
+
+    private val AUTOMATION = booleanPreferencesKey("automation")
+    private val TOKEN = stringPreferencesKey("automation_token")
+
+    fun isPending(preferences: Preferences): Boolean =
+        preferences.contains(RETIRED_AUTOMATION) || preferences.contains(RETIRED_TOKEN)
+
+    fun apply(preferences: Preferences): Preferences {
+        val updated = mutablePreferencesOf().apply { plusAssign(preferences) }
+
+        carryBoolean(updated)
+        carryToken(updated)
+
+        updated.remove(RETIRED_AUTOMATION)
+        updated.remove(RETIRED_TOKEN)
+        return updated
+    }
+
+    private fun carryBoolean(preferences: MutablePreferences) {
+        val retired = preferences[RETIRED_AUTOMATION] ?: return
+        if (preferences.contains(AUTOMATION)) return
+
+        preferences[AUTOMATION] = retired
+    }
+
+    private fun carryToken(preferences: MutablePreferences) {
+        val retired = preferences[RETIRED_TOKEN] ?: return
+        if (preferences.contains(TOKEN)) return
+
+        preferences[TOKEN] = retired
+    }
+
+    fun migration(): DataMigration<Preferences> = object : DataMigration<Preferences> {
+        override suspend fun shouldMigrate(currentData: Preferences) = isPending(currentData)
+
+        override suspend fun migrate(currentData: Preferences) = apply(currentData)
+
+        override suspend fun cleanUp() = Unit
+    }
+}

--- a/app/src/main/java/dev/shizzi/SessionService.kt
+++ b/app/src/main/java/dev/shizzi/SessionService.kt
@@ -34,6 +34,8 @@ class SessionService : Service() {
 
     private var isStopping = false
 
+    private var reportTo: AutomationCommand? = null
+
     private var startJob: Job? = null
 
     private var generation = 0
@@ -48,6 +50,8 @@ class SessionService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         isStopping = intent?.action == ACTION_STOP
+        reportTo = intent?.getStringExtra(EXTRA_REPORT_AS)
+            ?.let { runCatching { AutomationCommand.valueOf(it) }.getOrNull() }
         startForeground(
             NOTIFICATION_ID,
             notification.build(
@@ -66,7 +70,10 @@ class SessionService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     private fun startSession() {
-        if (internalState.value.isBusy) return
+        if (internalState.value.isBusy) {
+            announceOutcome()
+            return
+        }
         val attempt = ++generation
         internalState.update {
             it.copy(isBusy = true, status = UiStatus.LOADING, lastError = "", detail = "")
@@ -91,6 +98,7 @@ class SessionService : Service() {
 
             internalState.update { current -> current.applyOutcome(outcome) }
             publishState()
+            announceOutcome()
             followStatus()
         }
     }
@@ -131,6 +139,8 @@ class SessionService : Service() {
                 controller.unbindAndStopDaemon()
             }
 
+            announceOutcome()
+
             if (stopped == generation) stopSelf()
         }
     }
@@ -166,6 +176,12 @@ class SessionService : Service() {
         }
     }
 
+    private fun announceOutcome() {
+        val command = reportTo ?: return
+        reportTo = null
+        AutomationResult.announce(this, command, internalState.value)
+    }
+
     private fun publishState() {
         notificationManager().notify(
             NOTIFICATION_ID,
@@ -187,6 +203,7 @@ class SessionService : Service() {
     companion object {
         private const val NOTIFICATION_ID = 1
         const val ACTION_STOP = "dev.shizzi.STOP_SESSION"
+        const val EXTRA_REPORT_AS = "reportAs"
 
         private val sessionState = MutableStateFlow(SessionUiState())
 
@@ -196,14 +213,23 @@ class SessionService : Service() {
 
         val isRunning: Boolean get() = liveService != null
 
-        fun start(context: Context) {
-            context.startForegroundService(Intent(context, SessionService::class.java))
+        fun start(context: Context, reportAs: AutomationCommand? = null) {
+            context.startForegroundService(
+                Intent(context, SessionService::class.java).reporting(reportAs),
+            )
         }
 
-        fun stop(context: Context) {
+        fun stop(context: Context, reportAs: AutomationCommand? = null) {
             context.startForegroundService(
-                Intent(context, SessionService::class.java).setAction(ACTION_STOP),
+                Intent(context, SessionService::class.java)
+                    .setAction(ACTION_STOP)
+                    .reporting(reportAs),
             )
+        }
+
+        private fun Intent.reporting(command: AutomationCommand?): Intent = when (command) {
+            null -> this
+            else -> putExtra(EXTRA_REPORT_AS, command.name)
         }
     }
 }

--- a/app/src/main/java/dev/shizzi/SessionViewModel.kt
+++ b/app/src/main/java/dev/shizzi/SessionViewModel.kt
@@ -86,6 +86,14 @@ class SessionViewModel(application: Application) : AndroidViewModel(application)
         permissionRequest.open(permission)
     }
 
+    fun setAutomation(isEnabled: Boolean) {
+        viewModelScope.launch { settingsStore.setAutomationEnabled(isEnabled) }
+    }
+
+    fun regenerateAutomationToken() {
+        viewModelScope.launch { settingsStore.setAutomationToken(AutomationToken.generate()) }
+    }
+
     fun setLogging(enabled: Boolean) {
         SessionLog.setEnabled(enabled)
         diagnostics.setLogging(enabled)

--- a/app/src/main/java/dev/shizzi/SettingsStore.kt
+++ b/app/src/main/java/dev/shizzi/SettingsStore.kt
@@ -22,7 +22,10 @@ data class Settings(
     val automationToken: String = "",
 )
 
-private val Context.dataStore: DataStore<Preferences> by preferencesDataStore("settings")
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "settings",
+    produceMigrations = { listOf(RenamedKeys.migration()) },
+)
 
 class SettingsStore(private val context: Context) {
 

--- a/app/src/main/java/dev/shizzi/SettingsStore.kt
+++ b/app/src/main/java/dev/shizzi/SettingsStore.kt
@@ -2,6 +2,7 @@ package dev.shizzi
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -16,6 +17,9 @@ data class Settings(
     val isLogging: Boolean = true,
 
     val hasCompletedOnboarding: Boolean = false,
+
+    val isAutomationEnabled: Boolean = false,
+    val automationToken: String = "",
 )
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore("settings")
@@ -23,6 +27,14 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore("s
 class SettingsStore(private val context: Context) {
 
     val settings: Flow<Settings> = context.dataStore.data.map(::toSettings)
+
+    suspend fun backfillTokenIfEnabled() {
+        context.dataStore.edit { preferences ->
+            if (preferences[AUTOMATION] != true) return@edit
+
+            preferences.mintTokenIfAbsent()
+        }
+    }
 
     suspend fun setTheme(choice: ThemeChoice) {
         context.dataStore.edit { it[THEME] = choice.name }
@@ -36,16 +48,37 @@ class SettingsStore(private val context: Context) {
         context.dataStore.edit { it[ONBOARDED] = hasCompleted }
     }
 
+    suspend fun setAutomationEnabled(isEnabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[AUTOMATION] = isEnabled
+            if (isEnabled) preferences.mintTokenIfAbsent()
+        }
+    }
+
+    suspend fun setAutomationToken(token: String) {
+        context.dataStore.edit { it[AUTOMATION_TOKEN] = token }
+    }
+
+    private fun MutablePreferences.mintTokenIfAbsent() {
+        if (!this[AUTOMATION_TOKEN].isNullOrEmpty()) return
+
+        this[AUTOMATION_TOKEN] = AutomationToken.generate()
+    }
+
     private fun toSettings(preferences: Preferences) = Settings(
         theme = runCatching { ThemeChoice.valueOf(preferences[THEME].orEmpty()) }
             .getOrDefault(ThemeChoice.SYSTEM),
         isLogging = preferences[LOGGING] ?: true,
         hasCompletedOnboarding = preferences[ONBOARDED] ?: false,
+        isAutomationEnabled = preferences[AUTOMATION] ?: false,
+        automationToken = preferences[AUTOMATION_TOKEN].orEmpty(),
     )
 
     private companion object {
         val THEME = stringPreferencesKey("theme")
         val LOGGING = booleanPreferencesKey("logging")
         val ONBOARDED = booleanPreferencesKey("onboarded")
+        val AUTOMATION = booleanPreferencesKey("automation")
+        val AUTOMATION_TOKEN = stringPreferencesKey("automation_token")
     }
 }

--- a/app/src/main/java/dev/shizzi/ui/AutomationSection.kt
+++ b/app/src/main/java/dev/shizzi/ui/AutomationSection.kt
@@ -1,0 +1,64 @@
+package dev.shizzi.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+
+data class AutomationState(
+    val isEnabled: Boolean,
+    val token: String,
+)
+
+data class AutomationActions(
+    val onSetEnabled: (Boolean) -> Unit,
+    val onRegenerateToken: () -> Unit,
+)
+
+@Composable
+fun AutomationSection(
+    state: AutomationState,
+    actions: AutomationActions,
+    toasts: ToastState,
+) {
+    SettingsToggle(
+        label = SettingsText(
+            title = "Automation",
+            subtitle = "Allows tasker apps to manage Shizzi",
+        ),
+        isChecked = state.isEnabled,
+        onCheckedChange = actions.onSetEnabled,
+    )
+
+    if (!state.isEnabled) return
+
+    val clipboard = LocalClipboardManager.current
+    var isExpanded by remember { mutableStateOf(false) }
+
+    SettingsAction(
+        label = SettingsText(title = "View setup instructions"),
+        onClick = { isExpanded = true },
+    )
+
+    TokenCard(
+        token = state.token,
+        actions = TokenActions(
+            onCopy = {
+                clipboard.setText(AnnotatedString(state.token))
+                toasts.show(copiedToast("Token"))
+            },
+            onRegenerate = actions.onRegenerateToken,
+        ),
+    )
+
+    if (!isExpanded) return
+
+    AutomationSetupDialog(
+        token = state.token,
+        toasts = toasts,
+        onDismiss = { isExpanded = false },
+    )
+}

--- a/app/src/main/java/dev/shizzi/ui/AutomationSetupDialog.kt
+++ b/app/src/main/java/dev/shizzi/ui/AutomationSetupDialog.kt
@@ -1,0 +1,119 @@
+package dev.shizzi.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.window.Dialog
+import dev.shizzi.Automation
+import dev.shizzi.AutomationCommand
+import dev.shizzi.ui.theme.ShizziTheme
+import dev.shizzi.ui.theme.brutalSurface
+
+private data class SetupField(val label: String, val value: String)
+
+@Composable
+fun AutomationSetupDialog(token: String, toasts: ToastState, onDismiss: () -> Unit) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .brutalSurface(fill = ShizziTheme.colors.surface)
+                .verticalScroll(rememberScrollState())
+                .padding(ShizziTheme.spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(ShizziTheme.spacing.md),
+        ) {
+            SetupContent(token = token, toasts = toasts)
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.SetupContent(token: String, toasts: ToastState) {
+    var command by remember { mutableStateOf(AutomationCommand.START) }
+
+    Text(
+        text = "Setup",
+        style = ShizziTheme.typography.heading,
+        color = ShizziTheme.colors.onSurface,
+    )
+
+    Text(
+        text = "Send a broadcast intent with these values.",
+        style = ShizziTheme.typography.body,
+        color = ShizziTheme.colors.onSurfaceMuted,
+    )
+
+    CopyableField(
+        field = SetupField("Action", Automation.actionFor(command)),
+        toasts = toasts,
+    )
+
+    CommandTabs(selected = command, onSelect = { command = it })
+
+    connectionFields(token).forEach { field ->
+        CopyableField(field = field, toasts = toasts)
+    }
+}
+
+private fun connectionFields(token: String) = listOf(
+    SetupField("Package", "dev.shizzi"),
+    SetupField("Class", "dev.shizzi.AutomationReceiver"),
+    SetupField("Target", "Broadcast receiver"),
+    SetupField("Extra name", Automation.EXTRA_TOKEN),
+    SetupField("Extra value", token),
+)
+
+@Composable
+private fun CopyableField(field: SetupField, toasts: ToastState) {
+    val clipboard = LocalClipboardManager.current
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(ShizziTheme.spacing.sm),
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(ShizziTheme.spacing.xs),
+        ) {
+            Text(
+                text = field.label.uppercase(),
+                style = ShizziTheme.typography.caption,
+                color = ShizziTheme.colors.onSurfaceMuted,
+            )
+
+            Text(
+                text = field.value,
+                style = ShizziTheme.typography.body.copy(fontFamily = FontFamily.Monospace),
+                color = ShizziTheme.colors.onSurface,
+            )
+        }
+
+        ShizziCompactIconButton(
+            icon = Icons.Filled.ContentCopy,
+            contentDescription = "Copy ${field.label.lowercase()}",
+            onClick = {
+                clipboard.setText(AnnotatedString(field.value))
+                toasts.show(copiedToast(field.label))
+            },
+        )
+    }
+}

--- a/app/src/main/java/dev/shizzi/ui/CommandTabs.kt
+++ b/app/src/main/java/dev/shizzi/ui/CommandTabs.kt
@@ -1,0 +1,37 @@
+package dev.shizzi.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.shizzi.AutomationCommand
+import dev.shizzi.ui.theme.ShizziTheme
+
+@Composable
+fun CommandTabs(
+    selected: AutomationCommand,
+    onSelect: (AutomationCommand) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(ShizziTheme.spacing.md),
+    ) {
+        AutomationCommand.entries.forEach { command ->
+            GhostButton(
+                label = labelFor(command),
+                onClick = { onSelect(command) },
+                isActive = command == selected,
+                padding = 0.dp,
+            )
+        }
+    }
+}
+
+private fun labelFor(command: AutomationCommand): String = when (command) {
+    AutomationCommand.START -> "Start"
+    AutomationCommand.STOP -> "Stop"
+    AutomationCommand.TOGGLE -> "Toggle"
+    AutomationCommand.QUERY_STATUS -> "Status"
+}

--- a/app/src/main/java/dev/shizzi/ui/GhostButton.kt
+++ b/app/src/main/java/dev/shizzi/ui/GhostButton.kt
@@ -1,0 +1,48 @@
+package dev.shizzi.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import dev.shizzi.ui.theme.ShizziTheme
+import dev.shizzi.ui.theme.isPressed
+
+@Composable
+fun GhostButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isActive: Boolean = false,
+    padding: Dp = ShizziTheme.spacing.md,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val colors = ShizziTheme.colors
+
+    Box(
+        modifier = modifier
+            .height(ShizziTheme.spacing.xxl)
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                onClick = onClick,
+            )
+            .padding(horizontal = padding),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label.uppercase(),
+            style = ShizziTheme.typography.caption,
+            color = when {
+                isActive || interaction.isPressed() -> colors.onSurface
+                else -> colors.onSurfaceMuted
+            },
+        )
+    }
+}

--- a/app/src/main/java/dev/shizzi/ui/IconButtons.kt
+++ b/app/src/main/java/dev/shizzi/ui/IconButtons.kt
@@ -15,6 +15,10 @@ import dev.shizzi.ui.theme.ShizziTheme
 
 private val IconSize = 24.dp
 
+private val CompactIconSize = 18.dp
+
+private val CompactTouchTarget = 32.dp
+
 @Composable
 fun ShizziIconButton(
     icon: ImageVector,
@@ -32,6 +36,25 @@ fun ShizziIconButton(
             contentDescription = contentDescription,
             tint = if (tint == Color.Unspecified) ShizziTheme.colors.onSurface else tint,
             modifier = Modifier.size(IconSize),
+        )
+    }
+}
+
+@Composable
+fun ShizziCompactIconButton(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier.size(CompactTouchTarget),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = ShizziTheme.colors.onSurfaceMuted,
+            modifier = Modifier.size(CompactIconSize),
         )
     }
 }

--- a/app/src/main/java/dev/shizzi/ui/SettingsPage.kt
+++ b/app/src/main/java/dev/shizzi/ui/SettingsPage.kt
@@ -33,6 +33,7 @@ data class SettingsState(
     val theme: ThemeChoice,
     val isLogging: Boolean,
     val isRunningDiagnostics: Boolean,
+    val automation: AutomationState,
 )
 
 data class SettingsActions(
@@ -43,12 +44,14 @@ data class SettingsActions(
     val onGrantPermission: (AppPermission) -> Unit,
     val onShizukuAction: () -> Unit,
     val onRestartOnboarding: () -> Unit,
+    val automation: AutomationActions,
 )
 
 @Composable
 fun SettingsPage(
     state: SettingsState,
     actions: SettingsActions,
+    toasts: ToastState,
     onBack: () -> Unit,
 ) {
     val isBusy = state.isRunningDiagnostics
@@ -75,6 +78,13 @@ fun SettingsPage(
                 ),
                 onGrantPermission = actions.onGrantPermission,
                 onShizukuAction = actions.onShizukuAction,
+            )
+
+            SectionLabel("Advanced")
+            AutomationSection(
+                state = state.automation,
+                actions = actions.automation,
+                toasts = toasts,
             )
 
             SectionLabel("Developer")

--- a/app/src/main/java/dev/shizzi/ui/Toast.kt
+++ b/app/src/main/java/dev/shizzi/ui/Toast.kt
@@ -38,6 +38,8 @@ object ToastKeys {
     const val DIAGNOSTICS = "diagnostics"
 
     const val CLEAR_LOG = "clear-log"
+
+    const val COPY = "copy"
 }
 
 class ToastState {
@@ -57,3 +59,8 @@ class ToastState {
 
 @Composable
 fun rememberToastState(): ToastState = remember { ToastState() }
+
+fun copiedToast(label: String): Toast = Toast(
+    key = ToastKeys.COPY,
+    message = "$label copied",
+)

--- a/app/src/main/java/dev/shizzi/ui/TokenCard.kt
+++ b/app/src/main/java/dev/shizzi/ui/TokenCard.kt
@@ -1,0 +1,73 @@
+package dev.shizzi.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import dev.shizzi.ui.theme.ShizziTheme
+import dev.shizzi.ui.theme.brutalSurface
+
+data class TokenActions(
+    val onCopy: () -> Unit,
+    val onRegenerate: () -> Unit,
+)
+
+@Composable
+fun TokenCard(token: String, actions: TokenActions) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .brutalSurface(fill = ShizziTheme.colors.surface)
+            .padding(
+                start = ShizziTheme.spacing.lg,
+                end = ShizziTheme.spacing.sm,
+                top = ShizziTheme.spacing.sm,
+                bottom = ShizziTheme.spacing.lg,
+            ),
+        verticalArrangement = Arrangement.spacedBy(ShizziTheme.spacing.sm),
+    ) {
+        TokenHeader(actions)
+
+        Text(
+            text = token,
+            style = ShizziTheme.typography.body.copy(fontFamily = FontFamily.Monospace),
+            color = ShizziTheme.colors.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun TokenHeader(actions: TokenActions) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Token",
+            style = ShizziTheme.typography.subheading,
+            color = ShizziTheme.colors.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+
+        ShizziCompactIconButton(
+            icon = Icons.Filled.ContentCopy,
+            contentDescription = "Copy token",
+            onClick = actions.onCopy,
+        )
+
+        ShizziCompactIconButton(
+            icon = Icons.Filled.Refresh,
+            contentDescription = "Regenerate token",
+            onClick = actions.onRegenerate,
+        )
+    }
+}

--- a/app/src/test/java/dev/shizzi/AppPermissionTest.kt
+++ b/app/src/test/java/dev/shizzi/AppPermissionTest.kt
@@ -1,5 +1,7 @@
 package dev.shizzi
 
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -14,9 +16,8 @@ class AppPermissionTest {
     }
 
     @Test
-    fun `every permission names the manifest permission it maps to`() {
-        AppPermission.entries.forEach { permission ->
-            assertTrue(permission.name, permission.manifestName.isNotBlank())
-        }
+    fun `every permission carries a manifest name or is granted another way`() {
+        assertNotNull(AppPermission.NOTIFICATIONS.manifestName)
+        assertNull(AppPermission.BATTERY_EXEMPTION.manifestName)
     }
 }

--- a/app/src/test/java/dev/shizzi/AutomationTest.kt
+++ b/app/src/test/java/dev/shizzi/AutomationTest.kt
@@ -1,0 +1,87 @@
+package dev.shizzi
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AutomationTest {
+
+    private val enabledWithoutToken = Settings(isAutomationEnabled = true)
+
+    private val enabledWithToken =
+        Settings(isAutomationEnabled = true, automationToken = "secret")
+
+    @Test
+    fun `refuses every command while automation is off`() {
+        val refusal = Automation.refuse(Settings(), presented = null)
+
+        assertEquals(AutomationRefusal.Disabled, refusal)
+    }
+
+    @Test
+    fun `refuses a correct token while automation is off`() {
+        val settings = Settings(automationToken = "secret")
+
+        val refusal = Automation.refuse(settings, presented = "secret")
+
+        assertEquals(AutomationRefusal.Disabled, refusal)
+    }
+
+    @Test
+    fun `refuses every caller when no token has been set`() {
+        assertEquals(
+            AutomationRefusal.BadToken,
+            Automation.refuse(enabledWithoutToken, presented = null),
+        )
+        assertEquals(
+            AutomationRefusal.BadToken,
+            Automation.refuse(enabledWithoutToken, presented = "anything"),
+        )
+    }
+
+    @Test
+    fun `accepts a matching token`() {
+        assertNull(Automation.refuse(enabledWithToken, presented = "secret"))
+    }
+
+    @Test
+    fun `refuses a missing token when one is required`() {
+        val refusal = Automation.refuse(enabledWithToken, presented = null)
+
+        assertEquals(AutomationRefusal.BadToken, refusal)
+    }
+
+    @Test
+    fun `refuses a wrong token of the same length`() {
+        val refusal = Automation.refuse(enabledWithToken, presented = "secreT")
+
+        assertEquals(AutomationRefusal.BadToken, refusal)
+    }
+
+    @Test
+    fun `refuses a token that is a prefix of the expected one`() {
+        val refusal = Automation.refuse(enabledWithToken, presented = "sec")
+
+        assertEquals(AutomationRefusal.BadToken, refusal)
+    }
+
+    @Test
+    fun `maps every published action to a command`() {
+        assertEquals(AutomationCommand.START, Automation.commandFor(Automation.ACTION_START))
+        assertEquals(AutomationCommand.STOP, Automation.commandFor(Automation.ACTION_STOP))
+        assertEquals(
+            AutomationCommand.TOGGLE,
+            Automation.commandFor(Automation.ACTION_TOGGLE),
+        )
+        assertEquals(
+            AutomationCommand.QUERY_STATUS,
+            Automation.commandFor(Automation.ACTION_QUERY_STATUS),
+        )
+    }
+
+    @Test
+    fun `does not treat an unknown or absent action as a command`() {
+        assertNull(Automation.commandFor("dev.shizzi.action.NOPE"))
+        assertNull(Automation.commandFor(null))
+    }
+}

--- a/app/src/test/java/dev/shizzi/RenamedKeysTest.kt
+++ b/app/src/test/java/dev/shizzi/RenamedKeysTest.kt
@@ -1,0 +1,85 @@
+package dev.shizzi
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import androidx.datastore.preferences.core.preferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RenamedKeysTest {
+
+    private val retiredAutomation = booleanPreferencesKey("external_control")
+    private val retiredToken = stringPreferencesKey("external_control_token")
+
+    private val automation = booleanPreferencesKey("automation")
+    private val token = stringPreferencesKey("automation_token")
+
+    @Test
+    fun `carries a retired setting onto the new key`() {
+        val before = preferencesOf(retiredAutomation to true, retiredToken to "secret")
+
+        val after = RenamedKeys.apply(before)
+
+        assertEquals(true, after[automation])
+        assertEquals("secret", after[token])
+    }
+
+    @Test
+    fun `drops the retired keys once carried`() {
+        val before = preferencesOf(retiredAutomation to true, retiredToken to "secret")
+
+        val after = RenamedKeys.apply(before)
+
+        assertNull(after[retiredAutomation])
+        assertNull(after[retiredToken])
+    }
+
+    @Test
+    fun `does not overwrite a value already under the new key`() {
+        val before = preferencesOf(
+            retiredToken to "old",
+            token to "current",
+        )
+
+        val after = RenamedKeys.apply(before)
+
+        assertEquals("current", after[token])
+    }
+
+    @Test
+    fun `leaves unrelated settings untouched`() {
+        val theme = stringPreferencesKey("theme")
+        val before = preferencesOf(retiredAutomation to true, theme to "DARK")
+
+        val after = RenamedKeys.apply(before)
+
+        assertEquals("DARK", after[theme])
+    }
+
+    @Test
+    fun `runs only while a retired key is present`() {
+        assertTrue(RenamedKeys.isPending(preferencesOf(retiredAutomation to false)))
+        assertTrue(RenamedKeys.isPending(preferencesOf(retiredToken to "secret")))
+    }
+
+    @Test
+    fun `does not run once migrated`() {
+        val migrated = preferencesOf(automation to true, token to "secret")
+
+        assertFalse(RenamedKeys.isPending(migrated))
+        assertFalse(RenamedKeys.isPending(mutablePreferencesOf()))
+    }
+
+    @Test
+    fun `carries a disabled setting rather than dropping it`() {
+        val before = preferencesOf(retiredAutomation to false)
+
+        val after = RenamedKeys.apply(before)
+
+        assertEquals(false, after[automation])
+    }
+}

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,94 @@
+# Automation
+
+Shizzi can be started and stopped by other apps — Tasker, MacroDroid, or
+anything else that can send an intent.
+
+## Enabling
+
+Off by default. Turn it on in **Settings › Advanced › Automation**.
+
+A token is generated when you turn automation on, and every command must
+carry it. The token card copies and regenerates it, and **Setup** lists every
+value an automation app needs, per action. Commands without a matching token are refused, so an app that does
+not know the token cannot control tethering.
+
+## Background starts
+
+Android 12 and up block an app in the background from starting a foreground
+service, which is what an intent-triggered session needs. Exemption from
+battery optimization is the documented way out of that restriction, and only
+the user can grant it.
+
+Grant **Background activity** in **Settings › Permissions**, or during
+onboarding. Until you do, commands are accepted but no session starts, and the
+log says so.
+
+## Actions
+
+Sent to `dev.shizzi/.AutomationReceiver` as a broadcast.
+
+| Action | Effect |
+| --- | --- |
+| `dev.shizzi.action.START` | Start a session |
+| `dev.shizzi.action.STOP` | Stop the session |
+| `dev.shizzi.action.TOGGLE` | Stop if running, otherwise start |
+| `dev.shizzi.action.QUERY_STATUS` | Report state without changing it |
+
+Pass the token as the string extra `token`.
+
+## Result
+
+Every command answers with a `dev.shizzi.action.SESSION_RESULT` broadcast.
+Because a start runs through Shizuku binding, interface setup, and upstream
+verification, this can arrive some seconds after the request — catch it rather
+than assuming the command took effect.
+
+The result is broadcast without a target package, so any app registered for
+that action can read it, including the session status, interface name, client
+count, and traffic counters. The token is never included. Commands themselves
+still need the token, so a listening app can observe a session but cannot
+start or stop one.
+
+| Extra | Type | Meaning |
+| --- | --- | --- |
+| `command` | string | The command being answered |
+| `accepted` | boolean | Whether the command passed the gate |
+| `refusal` | string | Why it was refused, when `accepted` is false |
+| `status` | string | `READY`, `LOADING`, `CONNECTED`, or `ERROR` |
+| `isActive` | boolean | Whether tethering is up |
+| `detail` | string | Human-readable state |
+| `interface` | string | Upstream interface name |
+| `error` | string | Failure reason, when one applies |
+| `clientCount` | int | Connected devices |
+| `bytesUp` / `bytesDown` | long | Session traffic |
+
+A refused command reports `accepted=false` and changes nothing.
+
+## Tasker
+
+Add a **System › Send Intent** action:
+
+- Action: `dev.shizzi.action.TOGGLE`
+- Package: `dev.shizzi`
+- Class: `dev.shizzi.AutomationReceiver`
+- Target: `Broadcast Receiver`
+- Extra: `token:your-token`
+
+To react to the result, add an **Event › System › Intent Received** profile
+with the action `dev.shizzi.action.SESSION_RESULT`. The extras above arrive as
+variables, so `%isActive` tells you whether tethering came up.
+
+## MacroDroid
+
+Use a **Send Intent** action with target `Broadcast`, the same action and
+class, and add `token` as a string extra. Catch the result with an
+**Intent Received** trigger on `dev.shizzi.action.SESSION_RESULT`.
+
+## adb
+
+Useful for checking a setup:
+
+```
+adb shell am broadcast -a dev.shizzi.action.QUERY_STATUS \
+  -n dev.shizzi/.AutomationReceiver --es token your-token
+```


### PR DESCRIPTION
Lets other apps start and stop tethering through intents, for automation from Tasker and MacroDroid. Off by default behind a Settings toggle, with an optional token. Every command answers with a `dev.shizzi.action.SESSION_RESULT` broadcast carrying session state, since a start settles seconds after the intent returns.

- `dev.shizzi.action.START` — start a session
- `dev.shizzi.action.STOP` — stop the session
- `dev.shizzi.action.TOGGLE` — stop if running, otherwise start
- `dev.shizzi.action.QUERY_STATUS` — report state without changing it
- `dev.shizzi.action.SESSION_RESULT` — broadcast out with the outcome