### PR TITLE
fix: keep hotspot state in sync after an upstream blip

### DIFF
--- a/app/src/main/java/dev/shizzi/SessionTeardown.kt
+++ b/app/src/main/java/dev/shizzi/SessionTeardown.kt
@@ -2,6 +2,38 @@ package dev.shizzi
 
 import android.content.Context
 
+/**
+ * Stops the hotspot, retrying while it stays tethered.
+ *
+ * stopTethering lands asynchronously, so a single immediate read can still see
+ * the downstream up. See https://github.com/carlelieser/shizzi/issues/22
+ */
+fun releaseDownstreamWith(
+    stop: () -> Boolean,
+    findTethered: () -> String?,
+    onRetry: (String) -> Unit = {},
+): String? {
+    var didAccept = false
+
+    for (attempt in 1..DOWNSTREAM_STOP_ATTEMPTS) {
+        didAccept = stop() || didAccept
+
+        val stillTethered = findTethered()
+        if (stillTethered == null) {
+            return when {
+                didAccept -> null
+                else -> "stopTethering was rejected, but no downstream remains tethered"
+            }
+        }
+        if (attempt == DOWNSTREAM_STOP_ATTEMPTS) return stillTethered
+
+        onRetry("$stillTethered; retrying stopTethering")
+    }
+    return "downstream did not release after $DOWNSTREAM_STOP_ATTEMPTS attempts"
+}
+
+const val DOWNSTREAM_STOP_ATTEMPTS = 3
+
 class SessionTeardown(private val context: Context) {
 
     private val inspector = UpstreamInspector()
@@ -53,22 +85,24 @@ class SessionTeardown(private val context: Context) {
 
     fun releaseDownstream(): String? {
         val control = DownstreamControl(context)
+        val inspector = DownstreamInspector()
 
-        val didAccept = runCatching { control.stopWifiTethering() }
+        return releaseDownstreamWith(
+            stop = { attemptStop(control) },
+            findTethered = {
+                runCatching { inspector.findTetheredDownstream() }
+                    .getOrElse { failure -> "could not verify downstream: ${failure.message}" }
+            },
+            onRetry = SessionLog::warn,
+        )
+    }
+
+    private fun attemptStop(control: DownstreamControl): Boolean =
+        runCatching { control.stopWifiTethering() }
             .getOrElse { failure ->
                 SessionLog.error("stopping the hotspot failed: ${failure.message}")
                 false
             }
-
-        val stillTethered = runCatching { DownstreamInspector().findTetheredDownstream() }
-            .getOrElse { failure -> "could not verify downstream: ${failure.message}" }
-
-        return when {
-            stillTethered != null -> stillTethered
-            didAccept -> null
-            else -> "stopTethering was rejected, but no downstream remains tethered"
-        }
-    }
 
     private companion object {
         const val UPSTREAM_POLL_MS = 500L

--- a/app/src/main/java/dev/shizzi/SessionWatchdog.kt
+++ b/app/src/main/java/dev/shizzi/SessionWatchdog.kt
@@ -12,7 +12,10 @@ class SessionWatchdog(
     private val isRunning = AtomicBoolean(false)
     private var thread: Thread? = null
 
-    private var consecutiveFailures = 0
+    private val tolerance = UpstreamTolerance(expectedInterface) { strike ->
+        Log.i(TAG, strike)
+        SessionLog.warn(strike)
+    }
 
     fun start() {
         if (!isRunning.compareAndSet(false, true)) return
@@ -48,38 +51,14 @@ class SessionWatchdog(
 
     private fun checkUpstream(): String? {
         val observation = inspector.observe()
-
         val names = observation.liveInterfaceNames(expectedInterface)
+        val reading = classifyUpstream(names, expectedInterface, observation.didTimeout)
 
-        val isHealthy = !observation.didTimeout &&
-            names.isNotEmpty() &&
-            names.all { it == expectedInterface }
-
-        if (isHealthy) {
-            consecutiveFailures = 0
-            return null
-        }
-
-        consecutiveFailures++
-        if (consecutiveFailures < FAILURES_BEFORE_TEARDOWN) {
-            Log.i(TAG, "upstream reads $names (strike $consecutiveFailures)")
-            SessionLog.warn(
-                "watchdog strike $consecutiveFailures/$FAILURES_BEFORE_TEARDOWN: " +
-                    "upstream reads $names, expected $expectedInterface",
-            )
-            return null
-        }
-
-        return when {
-            observation.didTimeout -> "upstream check timed out $consecutiveFailures times"
-            else -> "upstream drifted from $expectedInterface to $names"
-        }
+        return tolerance.judge(reading, names)
     }
 
     private companion object {
         const val TAG = "SessionWatchdog"
         const val POLL_INTERVAL_MS = 5_000L
-
-        const val FAILURES_BEFORE_TEARDOWN = 2
     }
 }

--- a/app/src/main/java/dev/shizzi/UpstreamVerdict.kt
+++ b/app/src/main/java/dev/shizzi/UpstreamVerdict.kt
@@ -1,0 +1,75 @@
+package dev.shizzi
+
+/**
+ * How a single upstream reading compares to the interface the session owns.
+ *
+ * An empty reading means tethering currently forwards nowhere, so no traffic can
+ * leak off the tun while it lasts. A drifted reading names a different live
+ * interface and does leak, so it is far less tolerable. See
+ * https://github.com/carlelieser/shizzi/issues/22
+ */
+enum class UpstreamReading { HEALTHY, ABSENT, TIMED_OUT, DRIFTED }
+
+fun classifyUpstream(
+    liveNames: List<String>,
+    expectedInterface: String,
+    didTimeout: Boolean,
+): UpstreamReading = when {
+    didTimeout -> UpstreamReading.TIMED_OUT
+    liveNames.isEmpty() -> UpstreamReading.ABSENT
+    liveNames.all { it == expectedInterface } -> UpstreamReading.HEALTHY
+    else -> UpstreamReading.DRIFTED
+}
+
+/**
+ * Tracks consecutive bad readings and decides when the session must end.
+ *
+ * Kept free of Android types so the tolerances are directly testable.
+ */
+class UpstreamTolerance(
+    private val expectedInterface: String,
+    private val onStrike: (String) -> Unit,
+) {
+
+    private var strikes = 0
+    private var lastReading = UpstreamReading.HEALTHY
+
+    fun judge(reading: UpstreamReading, names: List<String>): String? {
+        if (reading == UpstreamReading.HEALTHY) {
+            strikes = 0
+            lastReading = reading
+            return null
+        }
+
+        if (reading != lastReading) strikes = 0
+        lastReading = reading
+        strikes++
+
+        val allowed = allowedStrikes(reading)
+        if (strikes < allowed) {
+            onStrike("watchdog strike $strikes/$allowed: ${describe(reading, names)}")
+            return null
+        }
+        return describe(reading, names)
+    }
+
+    private fun allowedStrikes(reading: UpstreamReading): Int = when (reading) {
+        UpstreamReading.ABSENT -> ABSENT_STRIKES
+        else -> DRIFT_STRIKES
+    }
+
+    private fun describe(reading: UpstreamReading, names: List<String>): String = when (reading) {
+        UpstreamReading.TIMED_OUT -> "upstream check timed out $strikes times"
+        UpstreamReading.ABSENT ->
+            "upstream reported no interface for $strikes checks, expected $expectedInterface"
+
+        else -> "upstream drifted from $expectedInterface to $names"
+    }
+
+    private companion object {
+
+        const val DRIFT_STRIKES = 2
+
+        const val ABSENT_STRIKES = 12
+    }
+}

--- a/app/src/test/java/dev/shizzi/ReleaseDownstreamTest.kt
+++ b/app/src/test/java/dev/shizzi/ReleaseDownstreamTest.kt
@@ -1,0 +1,85 @@
+package dev.shizzi
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReleaseDownstreamTest {
+
+    private val tethered = "downstream still tethered: [ap_br_wlan2]"
+
+    @Test
+    fun `a downstream that releases on the first read needs one attempt`() {
+        var stops = 0
+
+        val problem = releaseDownstreamWith(
+            stop = { stops++; true },
+            findTethered = { null },
+        )
+
+        assertNull(problem)
+        assertEquals(1, stops)
+    }
+
+    @Test
+    fun `a downstream still up on the first read is stopped again`() {
+        var stops = 0
+
+        val problem = releaseDownstreamWith(
+            stop = { stops++; true },
+            findTethered = { if (stops < 2) tethered else null },
+        )
+
+        assertNull(problem)
+        assertEquals(2, stops)
+    }
+
+    @Test
+    fun `a downstream that never releases is reported`() {
+        var stops = 0
+
+        val problem = releaseDownstreamWith(
+            stop = { stops++; true },
+            findTethered = { tethered },
+        )
+
+        assertEquals(tethered, problem)
+        assertEquals(DOWNSTREAM_STOP_ATTEMPTS, stops)
+    }
+
+    @Test
+    fun `a rejected stop that leaves nothing tethered is still reported`() {
+        val problem = releaseDownstreamWith(
+            stop = { false },
+            findTethered = { null },
+        )
+
+        assertNotNull(problem)
+    }
+
+    @Test
+    fun `a later accepted stop clears an earlier rejection`() {
+        var stops = 0
+
+        val problem = releaseDownstreamWith(
+            stop = { stops++; stops > 1 },
+            findTethered = { if (stops < 2) tethered else null },
+        )
+
+        assertNull(problem)
+    }
+
+    @Test
+    fun `each retry is announced once`() {
+        val notices = mutableListOf<String>()
+
+        releaseDownstreamWith(
+            stop = { true },
+            findTethered = { tethered },
+            onRetry = { notices += it },
+        )
+
+        assertEquals(DOWNSTREAM_STOP_ATTEMPTS - 1, notices.size)
+    }
+}

--- a/app/src/test/java/dev/shizzi/UpstreamToleranceTest.kt
+++ b/app/src/test/java/dev/shizzi/UpstreamToleranceTest.kt
@@ -1,0 +1,86 @@
+package dev.shizzi
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class UpstreamToleranceTest {
+
+    private val expected = "testtun4"
+
+    private fun tolerance() = UpstreamTolerance(expected) {}
+
+    private fun classify(names: List<String>, didTimeout: Boolean = false) =
+        classifyUpstream(names, expected, didTimeout)
+
+    @Test
+    fun `an empty upstream reads as absent rather than drifted`() {
+        assertEquals(UpstreamReading.ABSENT, classify(emptyList()))
+    }
+
+    @Test
+    fun `another live interface reads as drifted`() {
+        assertEquals(UpstreamReading.DRIFTED, classify(listOf(expected, "rmnet_data2")))
+    }
+
+    @Test
+    fun `the owned interface alone is healthy`() {
+        assertEquals(UpstreamReading.HEALTHY, classify(listOf(expected)))
+    }
+
+    @Test
+    fun `a timeout outranks an otherwise healthy reading`() {
+        assertEquals(UpstreamReading.TIMED_OUT, classify(listOf(expected), didTimeout = true))
+    }
+
+    @Test
+    fun `a brief absent upstream does not end the session`() {
+        val guard = tolerance()
+
+        repeat(3) {
+            assertNull(guard.judge(UpstreamReading.ABSENT, emptyList()))
+        }
+    }
+
+    @Test
+    fun `an absent upstream that recovers clears its strikes`() {
+        val guard = tolerance()
+
+        repeat(5) { guard.judge(UpstreamReading.ABSENT, emptyList()) }
+        assertNull(guard.judge(UpstreamReading.HEALTHY, listOf(expected)))
+
+        repeat(5) {
+            assertNull(guard.judge(UpstreamReading.ABSENT, emptyList()))
+        }
+    }
+
+    @Test
+    fun `a sustained absent upstream still ends the session`() {
+        val guard = tolerance()
+        val verdicts = (1..12).map { guard.judge(UpstreamReading.ABSENT, emptyList()) }
+
+        assertNull(verdicts[10])
+        assertNotNull(verdicts[11])
+    }
+
+    @Test
+    fun `drift off the owned interface ends the session on the second strike`() {
+        val guard = tolerance()
+        val drifted = listOf("rmnet_data2")
+
+        assertNull(guard.judge(UpstreamReading.DRIFTED, drifted))
+        assertNotNull(guard.judge(UpstreamReading.DRIFTED, drifted))
+    }
+
+    @Test
+    fun `drift is not excused by earlier absent readings`() {
+        val guard = tolerance()
+        val drifted = listOf("rmnet_data2")
+
+        repeat(5) { guard.judge(UpstreamReading.ABSENT, emptyList()) }
+
+        assertNull(guard.judge(UpstreamReading.DRIFTED, drifted))
+        assertNotNull(guard.judge(UpstreamReading.DRIFTED, drifted))
+    }
+}


### PR DESCRIPTION
Addresses #22.

## What the log showed

The reporter's log pinned the sequence exactly:

```
51  12:38:09.421  watchdog strike 1/2: upstream reads [], expected testtun4
52  12:38:14.628  upstream drift: upstream drifted from testtun4 to []
54  12:38:19.401  upstream released: tethering moved off testtun4
55  12:38:19.407  teardown: downstream still tethered: [ap_br_wlan2]
56  12:38:19.408  session summary: active 2h 43m, 49 MB up, 466 MB down
```

Two separate faults stacked into the reported symptom.

## 1. A briefly absent upstream was treated as drift

`SessionWatchdog` required `names.isNotEmpty()` to call a reading healthy, so an
empty upstream list counted as a strike. Two strikes at a 5s poll means a ~10s
blip ends the session — and the same log shows a VPN reconnect a few minutes
later (`vpn strike 1/2`, `vpn replaced: ... re-pinning`), which is exactly the
kind of event that briefly empties the tethering upstream list. A 2h 43m session
died to a transient reading.

Empty and drifted are now distinct readings:

- **absent** (`[]`) — tethering forwards nowhere, so no traffic can leak off the
  tun. Tolerated for 12 consecutive polls (~60s), then still torn down.
- **drifted** (another live interface) — traffic *is* leaking onto the metered
  path. Unchanged: torn down on the second strike.

Strikes reset when the reading changes, so absent readings can't soften a
subsequent real drift.

## 2. Teardown gave up on the hotspot after one attempt

`releaseDownstream()` called `stopWifiTethering()` once and immediately read the
downstream back. `stopTethering` lands asynchronously, so that read can still see
`ap_br_wlan2` — which is what happened. It now retries up to 3 times, mirroring
the polling `releaseUpstreamSelection()` right below it already does.

Worst case adds ~6s to teardown (the stop call already sleeps 3s internally),
which also bounds the two `ProbeRunner` diagnostics paths that share this method.

## Safety

The watchdog is what stops traffic leaking onto the metered hotspot allowance, so
the change is deliberately asymmetric: only the *absent* case is relaxed, and only
with a hard 60s ceiling. Drift onto a real interface still ends the session in two
strikes, exactly as before. Worth noting `liveInterfaceNames()` already drops
interfaces missing from `/sys/class/net`, so `[]` is partly produced by the app's
own filtering rather than being a pure OS reading.

The decision logic moved into pure functions (`classifyUpstream`,
`UpstreamTolerance`, `releaseDownstreamWith`) so the tolerances are directly
testable; the Android-facing classes are unchanged in shape.

## Not addressed here

Once a session ends, nothing re-checks the OS: `SessionStatusPoller` only runs
while status is `CONNECTED`, so a stale "READY" cannot self-correct — which is why
the reporter needed an app restart. The session also ended in `ERROR` with
`downstream still tethered`, yet the UI showed a plain `READY` with no error.
Both are worth a follow-up; this PR fixes the causes rather than the recovery.

## Testing

13 new unit tests, all verified to fail against the pre-fix constants. Full suite
(33 tests) and `assembleDebug` pass.

Draft pending confirmation from the reporter that the built APK no longer shows
the desync.